### PR TITLE
Auto-suggest relationships

### DIFF
--- a/apps/api/test/relationships.e2e.spec.ts
+++ b/apps/api/test/relationships.e2e.spec.ts
@@ -847,6 +847,39 @@ describe("Treemich API routes", () => {
       expect(json.familyViewStyle).toBe("hybridTreeList");
     });
 
+    it("persists dismissed suggestion keys alongside existing preferences", async () => {
+      const existing = {
+        familyViewStyle: "generationTree",
+        graphFilterVisibility: {
+          parentChild: true,
+          spouse: true,
+          sibling: true,
+          friends: false,
+          pets: false
+        }
+      };
+      const merged = {
+        ...existing,
+        dismissedSuggestions: ["parent:casey:alex", "sibling:alex:blair"]
+      };
+      treemichUserFindUniqueOrThrowMock.mockResolvedValueOnce({ preferences: existing });
+      treemichUserUpdateMock.mockResolvedValueOnce({ preferences: merged });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/user/preferences",
+        payload: { dismissedSuggestions: ["parent:casey:alex", "sibling:alex:blair"] }
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(merged);
+      expect(treemichUserUpdateMock).toHaveBeenCalledWith({
+        where: { id: "user-1" },
+        data: { preferences: merged },
+        select: { preferences: true }
+      });
+    });
+
     it("rejects invalid familyViewStyle values", async () => {
       const response = await app.inject({
         method: "PATCH",

--- a/apps/web/src/components/PeopleGraph3D.tsx
+++ b/apps/web/src/components/PeopleGraph3D.tsx
@@ -48,7 +48,7 @@ type Props = {
     targetPersonId: string,
     relationshipType: RelationshipType
   ) => Promise<void>;
-  onPreferencesChange: (prefs: UserPreferences) => void;
+  onPreferencesChange: (prefs: Partial<UserPreferences>) => void;
 };
 
 const DEFAULT_RENDER_LIMIT = 120;

--- a/apps/web/src/components/PersonDetailPanel.tsx
+++ b/apps/web/src/components/PersonDetailPanel.tsx
@@ -1,6 +1,11 @@
 import { memo, useEffect, useMemo, useState } from "react";
 import type { Gender, ImmichPerson, RelationshipRecord, RelationshipType } from "../lib/api";
 import { personThumbnailUrl } from "../lib/api";
+import {
+  computeSuggestions,
+  getSuggestionRelationshipLabel,
+  type RelationshipSuggestion
+} from "./graph/relationshipSuggestions";
 import { inverseRelationshipType } from "./graph/layout";
 
 type RelativeItem = {
@@ -17,6 +22,7 @@ type Props = {
   person: ImmichPerson | null;
   people: ImmichPerson[];
   relationships: RelationshipRecord[];
+  dismissedSuggestionKeys: string[];
   genders: Gender[];
   genderValue: Gender;
   birthDateValue: string;
@@ -25,14 +31,22 @@ type Props = {
   onProfileSave: () => void;
   isSavingProfile: boolean;
   onFocusPerson: (personId: string) => void;
+  onCreateRelationship: (
+    sourcePersonId: string,
+    targetPersonId: string,
+    relationshipType: RelationshipType
+  ) => Promise<void>;
   onUpdateRelationship: (
     relationship: RelationshipRecord,
     relatedPersonId: string,
     relationshipType: RelationshipType
   ) => Promise<void>;
   onDeleteRelationship: (relationship: RelationshipRecord, relatedPersonId: string) => Promise<void>;
+  onDismissSuggestion: (suggestionKey: string) => void;
   isSavingRelationship: boolean;
 };
+
+const maxVisibleSuggestions = 5;
 
 const relationshipLabel: Record<RelationshipRecord["type"], string> = {
   PARENT_OF: "Parent",
@@ -121,6 +135,7 @@ const PersonDetailPanelComponent = ({
   person,
   people,
   relationships,
+  dismissedSuggestionKeys,
   genders,
   genderValue,
   birthDateValue,
@@ -129,13 +144,16 @@ const PersonDetailPanelComponent = ({
   onProfileSave,
   isSavingProfile,
   onFocusPerson,
+  onCreateRelationship,
   onUpdateRelationship,
   onDeleteRelationship,
+  onDismissSuggestion,
   isSavingRelationship
 }: Props) => {
   const [editingRelationshipKey, setEditingRelationshipKey] = useState<string | null>(null);
   const [editingRelationshipType, setEditingRelationshipType] = useState<RelationshipType>("SIBLING_OF");
   const [pendingDeleteKey, setPendingDeleteKey] = useState<string | null>(null);
+  const [visibleSuggestionCount, setVisibleSuggestionCount] = useState(maxVisibleSuggestions);
 
   const relatives = useMemo<RelativeItem[]>(() => {
     if (!person) {
@@ -187,6 +205,12 @@ const PersonDetailPanelComponent = ({
         left.relatedName.localeCompare(right.relatedName)
     );
   }, [people, person, relationships]);
+  const suggestions = useMemo<RelationshipSuggestion[]>(
+    () => (person ? computeSuggestions(person.id, people, relationships, dismissedSuggestionKeys) : []),
+    [dismissedSuggestionKeys, people, person, relationships]
+  );
+  const visibleSuggestions = suggestions.slice(0, visibleSuggestionCount);
+  const remainingSuggestionCount = suggestions.length - visibleSuggestions.length;
 
   const activeRelationship =
     relatives.find((relationship) => relationship.key === editingRelationshipKey) ?? null;
@@ -205,6 +229,7 @@ const PersonDetailPanelComponent = ({
   useEffect(() => {
     setEditingRelationshipKey(null);
     setPendingDeleteKey(null);
+    setVisibleSuggestionCount(maxVisibleSuggestions);
   }, [person?.id]);
 
   useEffect(() => {
@@ -244,6 +269,17 @@ const PersonDetailPanelComponent = ({
     if (editingRelationshipKey === relationship.key) {
       setEditingRelationshipKey(null);
     }
+  };
+
+  const handleSuggestionAccept = async (suggestion: RelationshipSuggestion) => {
+    if (!person) {
+      return;
+    }
+    await onCreateRelationship(person.id, suggestion.personId, suggestion.suggestedType);
+  };
+
+  const handleSuggestionDismiss = (suggestionKey: string) => {
+    onDismissSuggestion(suggestionKey);
   };
 
   return (
@@ -361,6 +397,77 @@ const PersonDetailPanelComponent = ({
               <p className="hint">No relationships found yet.</p>
             )}
           </div>
+          {suggestions.length > 0 ? (
+            <div className="person-detail-section stack">
+              <div className="person-detail-section-header">
+                <div className="stack">
+                  <h3>Suggested Relationships</h3>
+                  <p className="hint">Suggestions are inferred from the existing family graph.</p>
+                </div>
+                <span className="person-detail-count">
+                  {suggestions.length > visibleSuggestions.length
+                    ? `${visibleSuggestions.length} of ${suggestions.length}`
+                    : suggestions.length}
+                </span>
+              </div>
+              <ul className="relatives-list">
+                {visibleSuggestions.map((suggestion) => (
+                  <li key={suggestion.key} className="relative-card suggestion-card">
+                    <div className="relative-main suggestion-main">
+                      <div className="relative-summary">
+                        <img
+                          className="relative-avatar"
+                          src={personThumbnailUrl(suggestion.personId)}
+                          alt={suggestion.personName}
+                        />
+                        <button
+                          type="button"
+                          className="text-link-button relative-name-button"
+                          onClick={() => onFocusPerson(suggestion.personId)}
+                        >
+                          {suggestion.personName}
+                        </button>
+                        <span className="relative-pill">
+                          {getSuggestionRelationshipLabel(suggestion.suggestedType)}
+                        </span>
+                      </div>
+                      <p className="hint suggestion-reason">{suggestion.reason}</p>
+                    </div>
+                    <div className="relative-actions">
+                      <button
+                        type="button"
+                        disabled={isSavingRelationship}
+                        onClick={() => void handleSuggestionAccept(suggestion)}
+                      >
+                        {isSavingRelationship
+                          ? "Saving..."
+                          : `Add as ${getSuggestionRelationshipLabel(suggestion.suggestedType)}`}
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary-button"
+                        disabled={isSavingRelationship}
+                        onClick={() => handleSuggestionDismiss(suggestion.key)}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              {remainingSuggestionCount > 0 ? (
+                <button
+                  type="button"
+                  className="secondary-button suggestion-show-more-button"
+                  onClick={() => setVisibleSuggestionCount(suggestions.length)}
+                  disabled={isSavingRelationship}
+                >
+                  Show {remainingSuggestionCount} more suggestion
+                  {remainingSuggestionCount === 1 ? "" : "s"}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
           {activeRelationship ? (
             <div className="relationship-editor stack">
               <div className="person-detail-section-header">

--- a/apps/web/src/components/graph/relationshipSuggestions.spec.ts
+++ b/apps/web/src/components/graph/relationshipSuggestions.spec.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import type { ImmichPerson, RelationshipRecord } from "../../lib/api";
+import { computeSuggestions } from "./relationshipSuggestions";
+
+const person = (id: string, name: string): ImmichPerson => ({
+  id,
+  name,
+  hasRelationship: false
+});
+
+const people: ImmichPerson[] = [
+  person("alex", "Alex"),
+  person("blair", "Blair"),
+  person("casey", "Casey"),
+  person("drew", "Drew"),
+  person("elliot", "Elliot"),
+  person("fran", "Fran"),
+  person("gray", "Gray"),
+  person("harper", "Harper"),
+  person("indigo", "Indigo"),
+  person("jules", "Jules"),
+  person("kai", "Kai"),
+  person("lane", "Lane")
+];
+
+const summary = (
+  selectedPersonId: string,
+  relationships: RelationshipRecord[],
+  dismissedKeys: string[] = []
+) =>
+  computeSuggestions(selectedPersonId, people, relationships, dismissedKeys).map((suggestion) => ({
+    key: suggestion.key,
+    personId: suggestion.personId,
+    suggestedType: suggestion.suggestedType,
+    reason: suggestion.reason
+  }));
+
+describe("computeSuggestions", () => {
+  it("suggests a missing sibling when two people share a parent", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        key: "sibling:alex:blair",
+        personId: "blair",
+        suggestedType: "SIBLING_OF",
+        reason: "Both are children of Casey."
+      }
+    ]);
+  });
+
+  it("suggests a missing parent connection from a sibling's parent", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "alex", toPersonId: "blair", type: "SIBLING_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        key: "parent:casey:alex",
+        personId: "casey",
+        suggestedType: "CHILD_OF",
+        reason: "Casey is already a parent of sibling Blair."
+      }
+    ]);
+  });
+
+  it("suggests a missing spouse when two people share a child", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "alex", toPersonId: "casey", type: "PARENT_OF" },
+      { fromPersonId: "blair", toPersonId: "casey", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        key: "spouse:alex:blair",
+        personId: "blair",
+        suggestedType: "SPOUSE_OF",
+        reason: "Both are parents of Casey."
+      }
+    ]);
+  });
+
+  it("suggests a spouse's child as a missing child relationship", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "alex", toPersonId: "blair", type: "SPOUSE_OF" },
+      { fromPersonId: "blair", toPersonId: "casey", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        key: "parent:alex:casey",
+        personId: "casey",
+        suggestedType: "PARENT_OF",
+        reason: "Casey is already connected as a child of spouse Blair."
+      }
+    ]);
+  });
+
+  it("deduplicates identical suggestions produced by multiple graph paths", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "drew", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" },
+      { fromPersonId: "drew", toPersonId: "blair", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.key).toBe("sibling:alex:blair");
+    expect(suggestions[0]?.reason).toBe("Both are children of Casey and Drew.");
+  });
+
+  it("uses the same symmetric suggestion key regardless of which person is selected", () => {
+    const relationships: RelationshipRecord[] = [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" }
+    ];
+
+    const alexSuggestion = computeSuggestions("alex", people, relationships, []);
+    const blairSuggestion = computeSuggestions("blair", people, relationships, []);
+
+    expect(alexSuggestion[0]?.key).toBe("sibling:alex:blair");
+    expect(blairSuggestion[0]?.key).toBe("sibling:alex:blair");
+  });
+
+  it("ignores malformed self-referential relationships", () => {
+    expect(
+      summary("alex", [
+        { fromPersonId: "alex", toPersonId: "alex", type: "SIBLING_OF" },
+        { fromPersonId: "alex", toPersonId: "alex", type: "SPOUSE_OF" },
+        { fromPersonId: "alex", toPersonId: "alex", type: "PARENT_OF" }
+      ])
+    ).toEqual([]);
+  });
+
+  it("does not suggest a relationship when the same semantic connection already exists", () => {
+    expect(
+      summary("alex", [
+        { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+        { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" },
+        { fromPersonId: "alex", toPersonId: "blair", type: "SIBLING_OF" }
+      ])
+    ).toEqual([]);
+
+    expect(
+      summary("alex", [
+        { fromPersonId: "alex", toPersonId: "casey", type: "PARENT_OF" },
+        { fromPersonId: "blair", toPersonId: "casey", type: "PARENT_OF" },
+        { fromPersonId: "alex", toPersonId: "blair", type: "SPOUSE_OF" }
+      ])
+    ).toEqual([]);
+  });
+
+  it("still suggests a missing relationship when only a different relationship type exists", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" },
+      { fromPersonId: "alex", toPersonId: "blair", type: "FRIEND_OF" }
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        key: "sibling:alex:blair",
+        personId: "blair",
+        suggestedType: "SIBLING_OF",
+        reason: "Both are children of Casey."
+      }
+    ]);
+  });
+
+  it("filters dismissed suggestions and keeps them dismissed after the graph is rebuilt", () => {
+    const relationships: RelationshipRecord[] = [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" }
+    ];
+    const dismissedKeys = ["sibling:alex:blair"];
+
+    expect(summary("alex", relationships, dismissedKeys)).toEqual([]);
+    expect(
+      summary(
+        "alex",
+        [
+          { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+          { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" }
+        ],
+        dismissedKeys
+      )
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for an empty graph", () => {
+    expect(summary("alex", [])).toEqual([]);
+  });
+
+  it("covers all sibling pairs in a large fan-out family", () => {
+    const familyPeople = [
+      person("parent", "Parent"),
+      ...Array.from({ length: 10 }, (_, index) => person(`child-${index + 1}`, `Child ${index + 1}`))
+    ];
+    const relationships: RelationshipRecord[] = familyPeople
+      .filter((entry) => entry.id !== "parent")
+      .map((entry) => ({
+        fromPersonId: "parent",
+        toPersonId: entry.id,
+        type: "PARENT_OF" as const
+      }));
+
+    const allKeys = new Set<string>();
+    for (const familyMember of familyPeople) {
+      if (familyMember.id === "parent") {
+        continue;
+      }
+      for (const suggestion of computeSuggestions(familyMember.id, familyPeople, relationships, [])) {
+        allKeys.add(suggestion.key);
+      }
+    }
+
+    expect(allKeys.size).toBe(45);
+  });
+
+  it("suggests a spouse even when there is only one shared child signal", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "alex", toPersonId: "casey", type: "PARENT_OF" },
+      { fromPersonId: "blair", toPersonId: "casey", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions[0]?.suggestedType).toBe("SPOUSE_OF");
+  });
+
+  it("includes the spouse name in step-parent suggestion reasons", () => {
+    const suggestions = summary("alex", [
+      { fromPersonId: "alex", toPersonId: "blair", type: "SPOUSE_OF" },
+      { fromPersonId: "blair", toPersonId: "casey", type: "PARENT_OF" }
+    ]);
+
+    expect(suggestions[0]?.reason).toContain("spouse Blair");
+  });
+
+  it("returns all suggestions and orders them deterministically", () => {
+    const relationships: RelationshipRecord[] = [
+      { fromPersonId: "casey", toPersonId: "alex", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "blair", type: "PARENT_OF" },
+      { fromPersonId: "casey", toPersonId: "kai", type: "PARENT_OF" },
+      { fromPersonId: "alex", toPersonId: "drew", type: "PARENT_OF" },
+      { fromPersonId: "elliot", toPersonId: "drew", type: "PARENT_OF" },
+      { fromPersonId: "alex", toPersonId: "fran", type: "SPOUSE_OF" },
+      { fromPersonId: "fran", toPersonId: "gray", type: "PARENT_OF" },
+      { fromPersonId: "alex", toPersonId: "harper", type: "SIBLING_OF" },
+      { fromPersonId: "indigo", toPersonId: "harper", type: "PARENT_OF" },
+      { fromPersonId: "lane", toPersonId: "harper", type: "PARENT_OF" }
+    ];
+
+    const forward = computeSuggestions("alex", people, relationships, []);
+    const reversed = computeSuggestions("alex", [...people].reverse(), [...relationships].reverse(), []);
+
+    expect(forward).toHaveLength(6);
+    expect(forward).toEqual(reversed);
+    expect(forward.map((entry) => entry.personId)).toEqual([
+      "blair",
+      "elliot",
+      "gray",
+      "indigo",
+      "kai",
+      "lane"
+    ]);
+  });
+});

--- a/apps/web/src/components/graph/relationshipSuggestions.ts
+++ b/apps/web/src/components/graph/relationshipSuggestions.ts
@@ -1,0 +1,274 @@
+import type { ImmichPerson, RelationshipRecord, RelationshipType } from "../../lib/api";
+import { buildParentChildIndex } from "./layout";
+
+export type RelationshipSuggestion = {
+  key: string;
+  personId: string;
+  personName: string;
+  suggestedType: RelationshipType;
+  reason: string;
+};
+
+const getSortedPair = (firstPersonId: string, secondPersonId: string) =>
+  firstPersonId < secondPersonId ? [firstPersonId, secondPersonId] : [secondPersonId, firstPersonId];
+
+const getSiblingKey = (firstPersonId: string, secondPersonId: string) => {
+  const [leftId, rightId] = getSortedPair(firstPersonId, secondPersonId);
+  return `sibling:${leftId}:${rightId}`;
+};
+
+const getSpouseKey = (firstPersonId: string, secondPersonId: string) => {
+  const [leftId, rightId] = getSortedPair(firstPersonId, secondPersonId);
+  return `spouse:${leftId}:${rightId}`;
+};
+
+const getParentChildKey = (parentId: string, childId: string) => `parent:${parentId}:${childId}`;
+
+const hasParentChildConnection = (
+  parentsByChild: Map<string, Set<string>>,
+  parentId: string,
+  childId: string
+) => parentsByChild.get(childId)?.has(parentId) ?? false;
+
+const buildSymmetricPairSet = (relationships: RelationshipRecord[], type: RelationshipType) => {
+  const pairs = new Set<string>();
+  for (const relationship of relationships) {
+    if (relationship.type !== type || relationship.fromPersonId === relationship.toPersonId) {
+      continue;
+    }
+    const [leftId, rightId] = getSortedPair(relationship.fromPersonId, relationship.toPersonId);
+    pairs.add(`${leftId}|${rightId}`);
+  }
+  return pairs;
+};
+
+const getSymmetricPairLookupKey = (firstPersonId: string, secondPersonId: string) => {
+  const [leftId, rightId] = getSortedPair(firstPersonId, secondPersonId);
+  return `${leftId}|${rightId}`;
+};
+
+const getPairPartnersForPerson = (pairKeys: Set<string>, personId: string) => {
+  const relatedIds = new Set<string>();
+  for (const pairKey of pairKeys) {
+    const [leftId, rightId] = pairKey.split("|");
+    if (leftId === personId && rightId) {
+      relatedIds.add(rightId);
+    } else if (rightId === personId && leftId) {
+      relatedIds.add(leftId);
+    }
+  }
+  return relatedIds;
+};
+
+const addSuggestion = (
+  suggestionsByKey: Map<string, RelationshipSuggestion>,
+  dismissedKeys: Set<string>,
+  peopleById: Map<string, ImmichPerson>,
+  suggestion: Omit<RelationshipSuggestion, "personName">
+) => {
+  if (dismissedKeys.has(suggestion.key) || suggestionsByKey.has(suggestion.key)) {
+    return;
+  }
+
+  const relatedPerson = peopleById.get(suggestion.personId);
+  if (!relatedPerson) {
+    return;
+  }
+
+  suggestionsByKey.set(suggestion.key, {
+    ...suggestion,
+    personName: relatedPerson.name
+  });
+};
+
+const siblingReason = (sharedParentNames: string[]) => {
+  if (sharedParentNames.length === 1) {
+    return `Both are children of ${sharedParentNames[0]}.`;
+  }
+  if (sharedParentNames.length === 2) {
+    return `Both are children of ${sharedParentNames[0]} and ${sharedParentNames[1]}.`;
+  }
+  return `They share parents: ${sharedParentNames.join(", ")}.`;
+};
+
+const parentReason = (parentName: string, siblingName: string) =>
+  `${parentName} is already a parent of sibling ${siblingName}.`;
+
+const spouseReason = (sharedChildNames: string[]) => {
+  if (sharedChildNames.length === 1) {
+    return `Both are parents of ${sharedChildNames[0]}.`;
+  }
+  if (sharedChildNames.length === 2) {
+    return `Both are parents of ${sharedChildNames[0]} and ${sharedChildNames[1]}.`;
+  }
+  return `They share children: ${sharedChildNames.join(", ")}.`;
+};
+
+const spousesChildReason = (spouseName: string, childName: string) =>
+  `${childName} is already connected as a child of spouse ${spouseName}.`;
+
+const compareSuggestions = (left: RelationshipSuggestion, right: RelationshipSuggestion) =>
+  left.personName.localeCompare(right.personName) ||
+  left.suggestedType.localeCompare(right.suggestedType) ||
+  left.personId.localeCompare(right.personId) ||
+  left.key.localeCompare(right.key);
+
+export const getSuggestionRelationshipLabel = (relationshipType: RelationshipType) => {
+  if (relationshipType === "CHILD_OF") {
+    return "Parent";
+  }
+  if (relationshipType === "PARENT_OF") {
+    return "Child";
+  }
+  if (relationshipType === "SPOUSE_OF") {
+    return "Spouse";
+  }
+  if (relationshipType === "FRIEND_OF") {
+    return "Friend";
+  }
+  if (relationshipType === "PET_OF") {
+    return "Pet";
+  }
+  return "Sibling";
+};
+
+export const computeSuggestions = (
+  selectedPersonId: string,
+  people: ImmichPerson[],
+  relationships: RelationshipRecord[],
+  dismissedKeys: string[]
+): RelationshipSuggestion[] => {
+  const peopleById = new Map(people.map((entry) => [entry.id, entry]));
+  if (!peopleById.has(selectedPersonId)) {
+    return [];
+  }
+
+  const dismissedKeySet = new Set(dismissedKeys);
+  const { parentsByChild, childrenByParent } = buildParentChildIndex(relationships);
+  const siblingPairs = buildSymmetricPairSet(relationships, "SIBLING_OF");
+  const spousePairs = buildSymmetricPairSet(relationships, "SPOUSE_OF");
+  const suggestionsByKey = new Map<string, RelationshipSuggestion>();
+
+  const selectedParents = [...(parentsByChild.get(selectedPersonId) ?? new Set<string>())];
+  const siblingParentIdsBySibling = new Map<string, Set<string>>();
+  for (const parentId of selectedParents) {
+    const siblingIds = childrenByParent.get(parentId) ?? new Set<string>();
+    for (const siblingId of siblingIds) {
+      if (siblingId === selectedPersonId) {
+        continue;
+      }
+
+      const siblingParents = siblingParentIdsBySibling.get(siblingId) ?? new Set<string>();
+      siblingParents.add(parentId);
+      siblingParentIdsBySibling.set(siblingId, siblingParents);
+    }
+  }
+
+  for (const [siblingId, sharedParentIds] of siblingParentIdsBySibling) {
+    if (siblingPairs.has(getSymmetricPairLookupKey(selectedPersonId, siblingId))) {
+      continue;
+    }
+
+    const sharedParentNames = [...sharedParentIds]
+      .map((parentId) => peopleById.get(parentId)?.name)
+      .filter((name): name is string => Boolean(name))
+      .sort((left, right) => left.localeCompare(right));
+
+    addSuggestion(suggestionsByKey, dismissedKeySet, peopleById, {
+      key: getSiblingKey(selectedPersonId, siblingId),
+      personId: siblingId,
+      suggestedType: "SIBLING_OF",
+      reason: siblingReason(sharedParentNames)
+    });
+  }
+
+  const siblingIdsForParentSuggestions = new Set<string>([
+    ...siblingParentIdsBySibling.keys(),
+    ...getPairPartnersForPerson(siblingPairs, selectedPersonId)
+  ]);
+  for (const siblingId of siblingIdsForParentSuggestions) {
+    const siblingParents = parentsByChild.get(siblingId) ?? new Set<string>();
+    for (const parentId of siblingParents) {
+      if (
+        parentId === selectedPersonId ||
+        hasParentChildConnection(parentsByChild, parentId, selectedPersonId)
+      ) {
+        continue;
+      }
+
+      const siblingName = peopleById.get(siblingId)?.name ?? "their sibling";
+      const parentName = peopleById.get(parentId)?.name ?? "This person";
+
+      addSuggestion(suggestionsByKey, dismissedKeySet, peopleById, {
+        key: getParentChildKey(parentId, selectedPersonId),
+        personId: parentId,
+        suggestedType: "CHILD_OF",
+        reason: parentReason(parentName, siblingName)
+      });
+    }
+  }
+
+  const selectedChildren = [...(childrenByParent.get(selectedPersonId) ?? new Set<string>())];
+  const coparentChildIdsByPerson = new Map<string, Set<string>>();
+  for (const childId of selectedChildren) {
+    const childParents = parentsByChild.get(childId) ?? new Set<string>();
+    for (const parentId of childParents) {
+      if (parentId === selectedPersonId) {
+        continue;
+      }
+
+      const childIds = coparentChildIdsByPerson.get(parentId) ?? new Set<string>();
+      childIds.add(childId);
+      coparentChildIdsByPerson.set(parentId, childIds);
+    }
+  }
+
+  for (const [coparentId, sharedChildIds] of coparentChildIdsByPerson) {
+    if (spousePairs.has(getSymmetricPairLookupKey(selectedPersonId, coparentId))) {
+      continue;
+    }
+
+    const sharedChildNames = [...sharedChildIds]
+      .map((childId) => peopleById.get(childId)?.name)
+      .filter((name): name is string => Boolean(name))
+      .sort((left, right) => left.localeCompare(right));
+
+    addSuggestion(suggestionsByKey, dismissedKeySet, peopleById, {
+      key: getSpouseKey(selectedPersonId, coparentId),
+      personId: coparentId,
+      suggestedType: "SPOUSE_OF",
+      reason: spouseReason(sharedChildNames)
+    });
+  }
+
+  for (const spousePairKey of spousePairs) {
+    const [leftId, rightId] = spousePairKey.split("|");
+    const spouseId = leftId === selectedPersonId ? rightId : rightId === selectedPersonId ? leftId : null;
+    if (!spouseId) {
+      continue;
+    }
+
+    const spouseChildren = childrenByParent.get(spouseId) ?? new Set<string>();
+    for (const childId of spouseChildren) {
+      if (
+        childId === selectedPersonId ||
+        hasParentChildConnection(parentsByChild, selectedPersonId, childId)
+      ) {
+        continue;
+      }
+
+      const spouseName = peopleById.get(spouseId)?.name ?? "their spouse";
+      const childName = peopleById.get(childId)?.name ?? "This person";
+      const key = getParentChildKey(selectedPersonId, childId);
+
+      addSuggestion(suggestionsByKey, dismissedKeySet, peopleById, {
+        key,
+        personId: childId,
+        suggestedType: "PARENT_OF",
+        reason: spousesChildReason(spouseName, childName)
+      });
+    }
+  }
+
+  return [...suggestionsByKey.values()].sort(compareSuggestions);
+};

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -114,10 +114,31 @@ export const PeoplePage = () => {
     [people, selectedPersonId]
   );
 
-  const onPreferencesChange = useCallback((prefs: UserPreferences) => {
-    setSavedPreferences(prefs);
-    updateUserPreferences(prefs).catch(() => {});
+  const onPreferencesChange = useCallback((prefs: Partial<UserPreferences>) => {
+    setSavedPreferences((current) => ({
+      ...(current ?? {}),
+      ...prefs,
+      dismissedSuggestions: prefs.dismissedSuggestions ?? current?.dismissedSuggestions,
+      familyViewStyle: prefs.familyViewStyle ?? current?.familyViewStyle,
+      graphFilterVisibility: prefs.graphFilterVisibility ?? current?.graphFilterVisibility
+    }));
+    updateUserPreferences(prefs)
+      .then((nextPrefs) => {
+        setSavedPreferences(nextPrefs);
+      })
+      .catch(() => {});
   }, []);
+
+  const onDismissSuggestion = useCallback(
+    (suggestionKey: string) => {
+      const dismissedSuggestions = new Set(savedPreferences?.dismissedSuggestions ?? []);
+      dismissedSuggestions.add(suggestionKey);
+      onPreferencesChange({
+        dismissedSuggestions: [...dismissedSuggestions].sort((left, right) => left.localeCompare(right))
+      });
+    },
+    [onPreferencesChange, savedPreferences?.dismissedSuggestions]
+  );
 
   const clearGraphFocus = useCallback(() => setGraphFocusPersonId(null), []);
 
@@ -268,6 +289,7 @@ export const PeoplePage = () => {
           person={selectedPerson}
           people={people}
           relationships={relationships}
+          dismissedSuggestionKeys={savedPreferences?.dismissedSuggestions ?? []}
           genders={genders}
           genderValue={selectedPerson ? (genderByPersonId[selectedPerson.id] ?? "UNKNOWN") : "UNKNOWN"}
           onGenderChange={handleGenderChange}
@@ -276,8 +298,10 @@ export const PeoplePage = () => {
           onProfileSave={onProfileSave}
           isSavingProfile={isSavingProfile}
           onFocusPerson={focusPersonInGraph}
+          onCreateRelationship={onCreateRelationship}
           onUpdateRelationship={onUpdateExistingRelationship}
           onDeleteRelationship={onDeleteExistingRelationship}
+          onDismissSuggestion={onDismissSuggestion}
           isSavingRelationship={isSavingRelationship}
         />
       </aside>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -591,6 +591,22 @@ body {
   text-align: left;
 }
 
+.suggestion-card {
+  align-items: flex-start;
+}
+
+.suggestion-main {
+  flex: 1 1 auto;
+}
+
+.suggestion-reason {
+  margin-left: 46px;
+}
+
+.suggestion-show-more-button {
+  width: 100%;
+}
+
 .person-detail-inline-summary {
   display: flex;
   flex-wrap: wrap;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -110,7 +110,8 @@ export const familyViewStyleSchema = z.enum(familyViewStyleValues);
 
 export const userPreferencesSchema = z.object({
   graphFilterVisibility: graphFilterVisibilitySchema.optional(),
-  familyViewStyle: familyViewStyleSchema.optional()
+  familyViewStyle: familyViewStyleSchema.optional(),
+  dismissedSuggestions: z.array(z.string()).optional()
 });
 
 export type GraphFilterVisibility = z.infer<typeof graphFilterVisibilitySchema>;


### PR DESCRIPTION
---
# Auto-Suggest Relationships

## Inference Rules

All suggestions are computed **client-side** since `relationships: RelationshipRecord[]` is already fully loaded in the frontend. No new API endpoints are needed for the inference logic itself.

### Rule 1: Missing Sibling

Two people share at least one parent but have no `SIBLING_OF` edge between them.

```
A --PARENT_OF--> B
A --PARENT_OF--> C
B and C have no SIBLING_OF edge
=> Suggest B SIBLING_OF C
```

### Rule 2: Missing Parent Connection

Two people are siblings, and one sibling has parent(s) that the other sibling is not connected to.

```
B --SIBLING_OF-- C
A --PARENT_OF--> B
A has no PARENT_OF edge to C
=> Suggest A PARENT_OF C
```

### Rule 3: Missing Spouse

Two people are both parents of the same child but have no `SPOUSE_OF` edge between them.

```
A --PARENT_OF--> C
B --PARENT_OF--> C
A and B have no SPOUSE_OF edge
=> Suggest A SPOUSE_OF B
```

### Rule 4: Spouse's Children

A person's spouse has children that the person is not connected to as a parent.

```
A --SPOUSE_OF-- B
B --PARENT_OF--> C
A has no PARENT_OF edge to C
=> Suggest A PARENT_OF C
```

## Future Rules (Not in Scope)

- **Photo co-occurrence suggestions** -- People who frequently appear in photos together but have no relationship. Would use the existing co-occurrence data as a weak/speculative signal. Needs a different UX (type picker rather than pre-selected type).
- **In-law / non-blood relative suggestions** -- Requires a new relationship type (e.g. `IN_LAW_OF`) to distinguish blood relatives from marriage-related connections. Would enable rules like suggesting in-law links between a person's siblings and their spouse's family.

## Dismissals (Persisted)

Dismissed suggestions are stored in the existing `UserPreferences` JSON column as a new optional field:

```ts
// In @treemich/shared userPreferencesSchema
dismissedSuggestions: z.array(z.string()).optional()
```

Each dismissed suggestion is stored as a deterministic key like `"sibling:personA:personB"` (IDs sorted alphabetically for symmetric relations). When the user dismisses a suggestion, it gets added to their preferences via the existing `PATCH /user/preferences` endpoint. No new API routes needed.

## Suggestion Engine (Frontend)

A new pure function in [apps/web/src/components/graph/relationshipSuggestions.ts](apps/web/src/components/graph/relationshipSuggestions.ts):

```ts
type RelationshipSuggestion = {
  key: string;                    // deterministic dedup/dismiss key
  personId: string;               // the other person (not the selected one)
  personName: string;
  suggestedType: RelationshipType;
  reason: string;                 // e.g. "Both are children of Mike"
};

function computeSuggestions(
  selectedPersonId: string,
  people: ImmichPerson[],
  relationships: RelationshipRecord[],
  dismissedKeys: string[]
): RelationshipSuggestion[]
```

This builds lookup maps (`parentsByChild`, `childrenByParent`, `siblingPairs`, `spousePairs`, `spouseOf`) from the flat relationship list, then applies the four rules, filtering out already-dismissed keys. The function is pure and memoizable.

## UI: "Suggested Relationships" Section

Added to [PersonDetailPanel.tsx](apps/web/src/components/PersonDetailPanel.tsx) below the existing "Relatives" section. Only shown when there are suggestions for the selected person.

```
+--------------------------------------------+
| Suggested Relationships           2 of 8   |
|--------------------------------------------|
| [avatar] Sarah                             |
| "Both are children of Mike"                |
| [Add as Sibling]              [Dismiss]    |
|--------------------------------------------|
| [avatar] John                              |
| "Mike is parent of sibling Sarah"          |
| [Add as Parent]               [Dismiss]    |
|                                            |
|          [Show 6 more suggestions]         |
+--------------------------------------------+
```

### Display cap and auto-fill

- **Cap at 5 visible suggestions** by default. If there are more, show a "Show N more suggestions" button at the bottom that reveals the rest.
- **Auto-fill on accept/dismiss**: When the user accepts or dismisses a suggestion and the visible count drops below 5, the next suggestion from the full list is automatically appended to the bottom of the visible list. The list never re-orders -- new items always appear at the bottom so the UI stays stable.

### Suggestion cards

Each suggestion card shows:
- Thumbnail + name of the suggested person (clickable to focus them in the graph)
- A short natural-language reason explaining why the relationship is inferred
- **Accept** button -- calls the existing `onCreateRelationship` callback, which creates the relationship and refreshes graph data (suggestion disappears automatically, next one fills in)
- **Dismiss** button -- adds the suggestion key to `dismissedSuggestions` in user preferences via `onPreferencesChange`, card fades out and next suggestion fills in

## Data Flow

```mermaid
flowchart TD
    subgraph data [Data Sources]
        Rels["relationships: RelationshipRecord[]"]
        People["people: ImmichPerson[]"]
        Prefs["savedPreferences.dismissedSuggestions"]
    end

    subgraph engine [Suggestion Engine]
        Compute["computeSuggestions()"]
    end

    subgraph ui [PersonDetailPanel]
        Section["Suggested Relationships section"]
        Accept["Accept -> onCreateRelationship"]
        Dismiss["Dismiss -> onPreferencesChange"]
    end

    Rels --> Compute
    People --> Compute
    Prefs --> Compute
    Compute --> Section
    Section --> Accept
    Section --> Dismiss
```

## Key Files to Modify

- [packages/shared/src/index.ts](packages/shared/src/index.ts) -- add `dismissedSuggestions` to `userPreferencesSchema`
- **New file**: `apps/web/src/components/graph/relationshipSuggestions.ts` -- pure suggestion engine + tests
- [apps/web/src/components/PersonDetailPanel.tsx](apps/web/src/components/PersonDetailPanel.tsx) -- add suggestions section, accept/dismiss handlers
- [apps/web/src/pages/people.tsx](apps/web/src/pages/people.tsx) -- pass `dismissedSuggestions` and dismiss callback through to the panel

## Testing

Unit tests in `apps/web/src/components/graph/relationshipSuggestions.spec.ts`:

### Rule coverage
- Rule 1: Two children of the same parent with no sibling edge -> suggests sibling
- Rule 2: Sibling has a parent the other sibling is not connected to -> suggests parent
- Rule 3: Two parents of the same child with no spouse edge -> suggests spouse
- Rule 4: Spouse's child that person is not parent of -> suggests parent

### Edge cases
- **Deduplication across rules**: Same suggestion produced by Rule 1 and Rule 2 only appears once
- **Symmetric key ordering**: Suggestion for A-B produces the same key regardless of which person is selected
- **Self-reference filtering**: Malformed edge where fromPersonId === toPersonId produces no suggestions
- **Already connected (same type)**: No suggestion when the specific relationship type already exists between the two people
- **Already connected (different type)**: Still suggests when a different type exists (e.g., friends who should also be siblings)
- **Dismissed suggestions filtered out**: Dismissed keys are excluded from results
- **Dismissed suggestion stays dismissed after re-adding the triggering relationship**: Deleting and re-creating the parent link doesn't resurrect a dismissed sibling suggestion
- **Empty graph**: Zero relationships produces zero suggestions with no errors
- **Large fan-out**: Parent with 10 children produces correct number of sibling suggestions (45 pairs)
- **Single-parent**: Two co-parents trigger spouse suggestion (dismiss handles user intent)
- **Blended family / step-parent**: Spouse's child suggestion includes clear reason text referencing the spouse

### Display behavior
- Returns all suggestions (display cap is a UI concern, not engine concern)
- Suggestions are deterministically ordered (stable across re-renders)

### E2E tests
- Dismiss persistence round-trip via `PATCH /user/preferences` (in existing `relationships.e2e.spec.ts`)
