### PR TITLE
GEDCOM Phase 6 - Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Optionally link an [Immich](https://immich.app/) account to import face thumbnai
 - **Per-person profiles** -- set gender, names, and Treemich **life events** (BIRTH/DEATH with optional places); quick-edit fields in the sidebar map to those events.
 - **3D graph visualization** -- interactive Three.js graph with multiple layout modes (generation tree, centered map, hybrid, cleaned 3D) plus layer toggles for Family/Friends/Pets.
 - **Natural-language search** -- query relationships in plain English with multi-hop graph traversal.
+- **Duplicate review and merge** -- recompute possible duplicate Treemich people, review scored reasons, dismiss candidates, and merge with explicit canonical-person confirmation.
 - **Photo co-occurrence** -- discover which people appear together in photos.
 - **Per-user privacy** -- all relationship data is scoped to the authenticated Treemich user.
 
@@ -81,6 +82,17 @@ Immich is an optional provider. Unlinking Immich removes stored provider credent
 - Immich assets, faces, and photos remain unchanged in Immich.
 
 Relink Immich to refresh thumbnails or import new co-occurrence data.
+
+### Duplicate review and merge (Phase D)
+
+Treemich stores duplicate candidates separately from validation findings. Use the **Duplicates** workspace to review possible duplicate people before any data changes happen.
+
+- **`GET /api/people/duplicates?status=PENDING`** — list persisted duplicate candidates.
+- **`POST /api/people/duplicates/recompute`** — recompute candidate pairs from names, alternate names, birth/death dates, close family graph overlap, and supporting co-occurrence signals.
+- **`PATCH /api/people/duplicates/:id`** — set candidate status to `PENDING` or `DISMISSED`.
+- **`POST /api/people/duplicates/:id/merge`** — merge after user confirmation. Body: `{ "canonicalPersonId": "...", "duplicatePersonId": "...", "confirm": true }`.
+
+Merge operates only on Treemich-owned people for the signed-in user. It moves known Treemich person references to the canonical person in one DB transaction, preserves distinct external identities, writes a `PersonMergeAudit` row, and deletes the duplicate profile last. It does **not** merge Immich faces or people.
 
 ### Upgrading from releases before legacy column removal
 
@@ -361,6 +373,10 @@ This starts the API on `localhost:4000` and the web app on `localhost:5173` with
 | `GET`    | `/people/:id/thumbnail`           | Person thumbnail (Immich or SVG initials fallback)      |
 | `GET`    | `/people/:id/external-identities` | List external identities (e.g. Immich)                  |
 | `POST`   | `/people/:id/external-identities` | Add an external identity link                           |
+| `GET`    | `/people/duplicates`              | List duplicate person candidates                        |
+| `POST`   | `/people/duplicates/recompute`    | Recompute duplicate person candidates                   |
+| `PATCH`  | `/people/duplicates/:id`          | Dismiss or reopen a duplicate candidate                 |
+| `POST`   | `/people/duplicates/:id/merge`    | Merge a reviewed duplicate into canonical person        |
 | `POST`   | `/people/:id/relationships`       | Create a relationship                                   |
 | `DELETE` | `/people/:id/relationships`       | Delete a relationship                                   |
 | `GET`    | `/relationships`                  | List all relationships (paginated)                      |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Optionally link an [Immich](https://immich.app/) account to import face thumbnai
 - **3D graph visualization** -- interactive Three.js graph with multiple layout modes (generation tree, centered map, hybrid, cleaned 3D) plus layer toggles for Family/Friends/Pets.
 - **Natural-language search** -- query relationships in plain English with multi-hop graph traversal.
 - **Duplicate review and merge** -- recompute possible duplicate Treemich people, review scored reasons, dismiss candidates, and merge with explicit canonical-person confirmation.
+- **Printable reports** -- generate pedigree, descendant, family group sheet, and register/narrative reports, then print or save to PDF from the browser.
 - **Photo co-occurrence** -- discover which people appear together in photos.
 - **Per-user privacy** -- all relationship data is scoped to the authenticated Treemich user.
 
@@ -47,6 +48,19 @@ Interoperability export as **GEDCOM 5.5.1** UTF-8 (`LINEAGE-LINKED`), including 
 - **`POST /api/export/gedcom/jobs`** — queues an async GEDCOM export. Poll **`GET /api/export/gedcom/jobs/:jobId`** for status; completed jobs include a session-authenticated result path and an expiring signed `downloadUrl` token. The signed token currently expires after 15 minutes.
 
 Disable the route in restrictive environments with **`TREEMICH_GEDCOM_EXPORT_ENABLED=false`** (default when unset: enabled).
+
+### Reports (Phase 6 / Phase E)
+
+The **Reports** workspace generates browser-printable genealogy reports from structured API data:
+
+- **`GET /api/reports/pedigree?rootPersonId=&depth=&redactLiving=`**
+- **`GET /api/reports/descendants?rootPersonId=&depth=&redactLiving=`**
+- **`GET /api/reports/family-group?familyId=&redactLiving=`**
+- **`GET /api/reports/register?rootPersonId=&depth=&redactLiving=`**
+
+Reports are session-authenticated and scoped to the current Treemich user. `redactLiving=true` keeps family structure but replaces people without a `DEATH` life event with `Living person` and suppresses dates, places, notes, alternate names, citations, and media details for those people.
+
+Depth defaults are pedigree `4`, descendants `3`, and register `3`. Operators can set **`TREEMICH_REPORT_MAX_DEPTH`** (default `6`, hard-capped at `10`) and **`TREEMICH_REPORT_MAX_PEOPLE`** (default `1000`). Requests above caps return validation errors instead of truncated reports. Server-side PDF jobs are intentionally not part of v1; use **Print / Save PDF** in the browser.
 
 ### GEDCOM import (Phase 5b)
 

--- a/apps/api/prisma/migrations/0028_phase_c_evidence_validation/migration.sql
+++ b/apps/api/prisma/migrations/0028_phase_c_evidence_validation/migration.sql
@@ -1,0 +1,110 @@
+-- Phase C: family media links and persisted validation findings.
+
+ALTER TYPE "MediaLinkTargetType" ADD VALUE IF NOT EXISTS 'FAMILY';
+
+-- Normalize duplicate links before enforcing one link per user/media/target.
+WITH ranked AS (
+    SELECT
+        "id",
+        "userId",
+        "mediaObjectId",
+        "targetType",
+        "targetId",
+        "notes",
+        ROW_NUMBER() OVER (
+            PARTITION BY "userId", "mediaObjectId", "targetType", "targetId"
+            ORDER BY "createdAt" ASC, "id" ASC
+        ) AS rn
+    FROM "MediaLink"
+),
+kept AS (
+    SELECT *
+    FROM ranked
+    WHERE rn = 1
+),
+duplicate_notes AS (
+    SELECT
+        k."id" AS "keptId",
+        STRING_AGG(DISTINCT NULLIF(BTRIM(d."notes"), ''), E'\n--- duplicate media link note ---\n') AS "notesToAppend"
+    FROM kept k
+    INNER JOIN ranked d
+        ON d."userId" = k."userId"
+       AND d."mediaObjectId" = k."mediaObjectId"
+       AND d."targetType" = k."targetType"
+       AND d."targetId" = k."targetId"
+       AND d.rn > 1
+    WHERE NULLIF(BTRIM(d."notes"), '') IS NOT NULL
+    GROUP BY k."id"
+)
+UPDATE "MediaLink" ml
+SET "notes" = CASE
+    WHEN NULLIF(BTRIM(ml."notes"), '') IS NULL THEN dn."notesToAppend"
+    ELSE ml."notes" || E'\n--- duplicate media link note ---\n' || dn."notesToAppend"
+END
+FROM duplicate_notes dn
+WHERE ml."id" = dn."keptId";
+
+WITH ranked AS (
+    SELECT
+        "id",
+        ROW_NUMBER() OVER (
+            PARTITION BY "userId", "mediaObjectId", "targetType", "targetId"
+            ORDER BY "createdAt" ASC, "id" ASC
+        ) AS rn
+    FROM "MediaLink"
+)
+DELETE FROM "MediaLink" ml
+USING ranked r
+WHERE ml."id" = r."id"
+  AND r.rn > 1;
+
+CREATE UNIQUE INDEX "MediaLink_userId_mediaObjectId_targetType_targetId_key"
+    ON "MediaLink"("userId", "mediaObjectId", "targetType", "targetId");
+
+CREATE TYPE "ValidationFindingStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'DISMISSED');
+CREATE TYPE "ValidationFindingSeverity" AS ENUM ('ERROR', 'WARNING');
+
+CREATE TABLE "ValidationFinding" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "severity" "ValidationFindingSeverity" NOT NULL,
+    "message" TEXT NOT NULL,
+    "personId" TEXT,
+    "relationshipId" TEXT,
+    "relatedPersonId" TEXT,
+    "familyId" TEXT,
+    "status" "ValidationFindingStatus" NOT NULL DEFAULT 'OPEN',
+    "fingerprint" TEXT NOT NULL,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "dismissedAt" TIMESTAMP(3),
+    "inProgressAt" TIMESTAMP(3),
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "ValidationFinding_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ValidationFinding_userId_fingerprint_key" ON "ValidationFinding"("userId", "fingerprint");
+CREATE INDEX "ValidationFinding_userId_status_idx" ON "ValidationFinding"("userId", "status");
+CREATE INDEX "ValidationFinding_userId_code_idx" ON "ValidationFinding"("userId", "code");
+CREATE INDEX "ValidationFinding_userId_severity_idx" ON "ValidationFinding"("userId", "severity");
+CREATE INDEX "ValidationFinding_userId_personId_idx" ON "ValidationFinding"("userId", "personId");
+CREATE INDEX "ValidationFinding_userId_relationshipId_idx" ON "ValidationFinding"("userId", "relationshipId");
+CREATE INDEX "ValidationFinding_userId_familyId_idx" ON "ValidationFinding"("userId", "familyId");
+
+ALTER TABLE "ValidationFinding" ADD CONSTRAINT "ValidationFinding_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "TreemichUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ValidationFinding" ADD CONSTRAINT "ValidationFinding_personId_fkey"
+    FOREIGN KEY ("personId") REFERENCES "PersonProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ValidationFinding" ADD CONSTRAINT "ValidationFinding_relationshipId_fkey"
+    FOREIGN KEY ("relationshipId") REFERENCES "Relationship"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ValidationFinding" ADD CONSTRAINT "ValidationFinding_relatedPersonId_fkey"
+    FOREIGN KEY ("relatedPersonId") REFERENCES "PersonProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ValidationFinding" ADD CONSTRAINT "ValidationFinding_familyId_fkey"
+    FOREIGN KEY ("familyId") REFERENCES "Family"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/0029_phase_d_person_duplicates/migration.sql
+++ b/apps/api/prisma/migrations/0029_phase_d_person_duplicates/migration.sql
@@ -1,0 +1,65 @@
+-- Phase D: persisted duplicate review queue and merge audit trail.
+
+CREATE TYPE "PersonDuplicateCandidateStatus" AS ENUM ('PENDING', 'DISMISSED', 'MERGED');
+
+CREATE TABLE "PersonDuplicateCandidate" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "personAId" TEXT NOT NULL,
+  "personBId" TEXT NOT NULL,
+  "score" INTEGER NOT NULL,
+  "reasons" JSONB NOT NULL DEFAULT '[]',
+  "status" "PersonDuplicateCandidateStatus" NOT NULL DEFAULT 'PENDING',
+  "dismissedAt" TIMESTAMP(3),
+  "mergedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "PersonDuplicateCandidate_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "PersonMergeAudit" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "candidateId" TEXT,
+  "canonicalPersonId" TEXT NOT NULL,
+  "duplicatePersonId" TEXT NOT NULL,
+  "changedCounts" JSONB NOT NULL DEFAULT '{}',
+  "warnings" JSONB NOT NULL DEFAULT '[]',
+  "externalIdentityPolicy" TEXT NOT NULL,
+  "metadata" JSONB NOT NULL DEFAULT '{}',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "PersonMergeAudit_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PersonDuplicateCandidate_userId_personAId_personBId_key"
+  ON "PersonDuplicateCandidate"("userId", "personAId", "personBId");
+CREATE INDEX "PersonDuplicateCandidate_userId_status_score_idx"
+  ON "PersonDuplicateCandidate"("userId", "status", "score");
+CREATE INDEX "PersonDuplicateCandidate_personAId_idx" ON "PersonDuplicateCandidate"("personAId");
+CREATE INDEX "PersonDuplicateCandidate_personBId_idx" ON "PersonDuplicateCandidate"("personBId");
+
+CREATE INDEX "PersonMergeAudit_userId_createdAt_idx" ON "PersonMergeAudit"("userId", "createdAt");
+CREATE INDEX "PersonMergeAudit_candidateId_idx" ON "PersonMergeAudit"("candidateId");
+CREATE INDEX "PersonMergeAudit_canonicalPersonId_idx" ON "PersonMergeAudit"("canonicalPersonId");
+
+ALTER TABLE "PersonDuplicateCandidate"
+  ADD CONSTRAINT "PersonDuplicateCandidate_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "TreemichUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PersonDuplicateCandidate"
+  ADD CONSTRAINT "PersonDuplicateCandidate_personAId_fkey"
+  FOREIGN KEY ("personAId") REFERENCES "PersonProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PersonDuplicateCandidate"
+  ADD CONSTRAINT "PersonDuplicateCandidate_personBId_fkey"
+  FOREIGN KEY ("personBId") REFERENCES "PersonProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PersonMergeAudit"
+  ADD CONSTRAINT "PersonMergeAudit_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "TreemichUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "PersonMergeAudit"
+  ADD CONSTRAINT "PersonMergeAudit_candidateId_fkey"
+  FOREIGN KEY ("candidateId") REFERENCES "PersonDuplicateCandidate"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "PersonMergeAudit"
+  ADD CONSTRAINT "PersonMergeAudit_canonicalPersonId_fkey"
+  FOREIGN KEY ("canonicalPersonId") REFERENCES "PersonProfile"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -104,6 +104,12 @@ enum ValidationFindingSeverity {
   WARNING
 }
 
+enum PersonDuplicateCandidateStatus {
+  PENDING
+  DISMISSED
+  MERGED
+}
+
 /// GEDCOM-style pedigree for a child within a family union (FAM / CHIL).
 enum FamilyChildPedigree {
   BIOLOGICAL
@@ -126,13 +132,13 @@ enum PersonThumbnailSource {
 }
 
 model TreemichUser {
-  id                       String                   @id @default(cuid())
+  id                       String                     @id @default(cuid())
   email                    String?
   name                     String?
   passwordHash             String?
-  preferences              Json                     @default("{}")
-  createdAt                DateTime                 @default(now())
-  updatedAt                DateTime                 @updatedAt
+  preferences              Json                       @default("{}")
+  createdAt                DateTime                   @default(now())
+  updatedAt                DateTime                   @updatedAt
   linkedAccount            LinkedImmichAccount?
   sessions                 TreemichSession[]
   profiles                 PersonProfile[]
@@ -152,6 +158,8 @@ model TreemichUser {
   mediaObjects             MediaObject[]
   mediaLinks               MediaLink[]
   validationFindings       ValidationFinding[]
+  duplicateCandidates      PersonDuplicateCandidate[]
+  personMergeAudits        PersonMergeAudit[]
   families                 Family[]
   gedcomImportJobs         GedcomImportJob[]
   gedcomExportJobs         GedcomExportJob[]
@@ -190,32 +198,35 @@ model TreemichSession {
 }
 
 model PersonProfile {
-  id                        String                   @id @default(cuid())
+  id                        String                     @id @default(cuid())
   userId                    String
-  gender                    Gender                   @default(UNKNOWN)
+  gender                    Gender                     @default(UNKNOWN)
   displayNameOverride       String?
   givenName                 String?
   surname                   String?
   nicknames                 String?
   /// Optional map for interchange (e.g. `{ "gedcomXref": "I42" }`). Not used by core UI yet.
-  externalIds               Json                     @default("{}")
-  createdAt                 DateTime                 @default(now())
-  updatedAt                 DateTime                 @updatedAt
-  user                      TreemichUser             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  externalIds               Json                       @default("{}")
+  createdAt                 DateTime                   @default(now())
+  updatedAt                 DateTime                   @updatedAt
+  user                      TreemichUser               @relation(fields: [userId], references: [id], onDelete: Cascade)
   externalIdentities        PersonExternalIdentity[]
   thumbnails                PersonThumbnail[]
-  fromRelationships         Relationship[]           @relation("FromPerson")
-  toRelationships           Relationship[]           @relation("ToPerson")
+  fromRelationships         Relationship[]             @relation("FromPerson")
+  toRelationships           Relationship[]             @relation("ToPerson")
   lifeEvents                LifeEvent[]
   personNames               PersonName[]
   researchTasks             ResearchTask[]
-  familiesAsParent1         Family[]                 @relation("FamilyParent1")
-  familiesAsParent2         Family[]                 @relation("FamilyParent2")
-  familiesAsChild           FamilyChild[]            @relation("FamilyChild")
-  cooccurrenceAsA           CooccurrenceEdge[]       @relation("CooccurrencePersonA")
-  cooccurrenceAsB           CooccurrenceEdge[]       @relation("CooccurrencePersonB")
-  validationFindings        ValidationFinding[]      @relation("ValidationFindingPerson")
-  relatedValidationFindings ValidationFinding[]      @relation("ValidationFindingRelatedPerson")
+  familiesAsParent1         Family[]                   @relation("FamilyParent1")
+  familiesAsParent2         Family[]                   @relation("FamilyParent2")
+  familiesAsChild           FamilyChild[]              @relation("FamilyChild")
+  cooccurrenceAsA           CooccurrenceEdge[]         @relation("CooccurrencePersonA")
+  cooccurrenceAsB           CooccurrenceEdge[]         @relation("CooccurrencePersonB")
+  validationFindings        ValidationFinding[]        @relation("ValidationFindingPerson")
+  relatedValidationFindings ValidationFinding[]        @relation("ValidationFindingRelatedPerson")
+  duplicateCandidateAsA     PersonDuplicateCandidate[] @relation("DuplicateCandidatePersonA")
+  duplicateCandidateAsB     PersonDuplicateCandidate[] @relation("DuplicateCandidatePersonB")
+  canonicalMergeAudits      PersonMergeAudit[]         @relation("PersonMergeAuditCanonical")
 
   @@index([userId])
   @@index([userId, givenName])
@@ -537,6 +548,49 @@ model ValidationFinding {
   @@index([userId, personId])
   @@index([userId, relationshipId])
   @@index([userId, familyId])
+}
+
+model PersonDuplicateCandidate {
+  id          String                         @id @default(cuid())
+  userId      String
+  personAId   String
+  personBId   String
+  score       Int
+  reasons     Json                           @default("[]")
+  status      PersonDuplicateCandidateStatus @default(PENDING)
+  dismissedAt DateTime?
+  mergedAt    DateTime?
+  createdAt   DateTime                       @default(now())
+  updatedAt   DateTime                       @updatedAt
+  user        TreemichUser                   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  personA     PersonProfile                  @relation("DuplicateCandidatePersonA", fields: [personAId], references: [id], onDelete: Cascade)
+  personB     PersonProfile                  @relation("DuplicateCandidatePersonB", fields: [personBId], references: [id], onDelete: Cascade)
+  mergeAudits PersonMergeAudit[]
+
+  @@unique([userId, personAId, personBId])
+  @@index([userId, status, score])
+  @@index([personAId])
+  @@index([personBId])
+}
+
+model PersonMergeAudit {
+  id                     String                    @id @default(cuid())
+  userId                 String
+  candidateId            String?
+  canonicalPersonId      String
+  duplicatePersonId      String
+  changedCounts          Json                      @default("{}")
+  warnings               Json                      @default("[]")
+  externalIdentityPolicy String
+  metadata               Json                      @default("{}")
+  createdAt              DateTime                  @default(now())
+  user                   TreemichUser              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  candidate              PersonDuplicateCandidate? @relation(fields: [candidateId], references: [id], onDelete: SetNull)
+  canonicalPerson        PersonProfile             @relation("PersonMergeAuditCanonical", fields: [canonicalPersonId], references: [id], onDelete: Restrict)
+
+  @@index([userId, createdAt])
+  @@index([candidateId])
+  @@index([canonicalPersonId])
 }
 
 model CooccurrenceSchedule {

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -89,6 +89,19 @@ enum MediaLinkTargetType {
   PERSON_PROFILE
   LIFE_EVENT
   SOURCE
+  FAMILY
+}
+
+enum ValidationFindingStatus {
+  OPEN
+  IN_PROGRESS
+  RESOLVED
+  DISMISSED
+}
+
+enum ValidationFindingSeverity {
+  ERROR
+  WARNING
 }
 
 /// GEDCOM-style pedigree for a child within a family union (FAM / CHIL).
@@ -113,93 +126,96 @@ enum PersonThumbnailSource {
 }
 
 model TreemichUser {
-  id                  String                @id @default(cuid())
-  email               String?
-  name                String?
-  passwordHash        String?
-  preferences         Json                  @default("{}")
-  createdAt           DateTime              @default(now())
-  updatedAt           DateTime              @updatedAt
-  linkedAccount       LinkedImmichAccount?
-  sessions            TreemichSession[]
-  profiles            PersonProfile[]
+  id                       String                   @id @default(cuid())
+  email                    String?
+  name                     String?
+  passwordHash             String?
+  preferences              Json                     @default("{}")
+  createdAt                DateTime                 @default(now())
+  updatedAt                DateTime                 @updatedAt
+  linkedAccount            LinkedImmichAccount?
+  sessions                 TreemichSession[]
+  profiles                 PersonProfile[]
   personExternalIdentities PersonExternalIdentity[]
-  personThumbnails    PersonThumbnail[]
-  relationships       Relationship[]
-  places              Place[]
-  lifeEvents          LifeEvent[]
-  cooccurrenceJobs    CooccurrenceJob[]
-  cooccurrenceEdges   CooccurrenceEdge[]
-  cooccurrenceSchedule CooccurrenceSchedule?
-  personNames         PersonName[]
-  researchTasks       ResearchTask[]
-  repositories        Repository[]
-  sources             Source[]
-  citations           Citation[]
-  mediaObjects        MediaObject[]
-  mediaLinks          MediaLink[]
-  families            Family[]
-  gedcomImportJobs    GedcomImportJob[]
-  gedcomExportJobs    GedcomExportJob[]
+  personThumbnails         PersonThumbnail[]
+  relationships            Relationship[]
+  places                   Place[]
+  lifeEvents               LifeEvent[]
+  cooccurrenceJobs         CooccurrenceJob[]
+  cooccurrenceEdges        CooccurrenceEdge[]
+  cooccurrenceSchedule     CooccurrenceSchedule?
+  personNames              PersonName[]
+  researchTasks            ResearchTask[]
+  repositories             Repository[]
+  sources                  Source[]
+  citations                Citation[]
+  mediaObjects             MediaObject[]
+  mediaLinks               MediaLink[]
+  validationFindings       ValidationFinding[]
+  families                 Family[]
+  gedcomImportJobs         GedcomImportJob[]
+  gedcomExportJobs         GedcomExportJob[]
 }
 
 model LinkedImmichAccount {
-  id                  String       @id @default(cuid())
-  userId              String       @unique
-  immichBaseUrl       String
-  immichUserId        String
-  immichEmail         String
-  immichName          String
+  id                   String       @id @default(cuid())
+  userId               String       @unique
+  immichBaseUrl        String
+  immichUserId         String
+  immichEmail          String
+  immichName           String
   encryptedAccessToken String
-  accessTokenIv       String
-  accessTokenTag      String
+  accessTokenIv        String
+  accessTokenTag       String
   accessTokenExpiresAt DateTime?
-  lastValidatedAt     DateTime?
-  createdAt           DateTime     @default(now())
-  updatedAt           DateTime     @updatedAt
-  user                TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  lastValidatedAt      DateTime?
+  createdAt            DateTime     @default(now())
+  updatedAt            DateTime     @updatedAt
+  user                 TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([immichBaseUrl, immichUserId])
 }
 
 model TreemichSession {
-  id         String       @id @default(cuid())
-  userId     String
-  tokenHash  String       @unique
-  expiresAt  DateTime
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
-  user       TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id        String       @id @default(cuid())
+  userId    String
+  tokenHash String       @unique
+  expiresAt DateTime
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  user      TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([expiresAt])
 }
 
 model PersonProfile {
-  id                  String         @id @default(cuid())
-  userId              String
-  gender              Gender         @default(UNKNOWN)
-  displayNameOverride String?
-  givenName           String?
-  surname             String?
-  nicknames           String?
+  id                        String                   @id @default(cuid())
+  userId                    String
+  gender                    Gender                   @default(UNKNOWN)
+  displayNameOverride       String?
+  givenName                 String?
+  surname                   String?
+  nicknames                 String?
   /// Optional map for interchange (e.g. `{ "gedcomXref": "I42" }`). Not used by core UI yet.
-  externalIds         Json           @default("{}")
-  createdAt           DateTime       @default(now())
-  updatedAt           DateTime       @updatedAt
-  user                TreemichUser   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  externalIdentities  PersonExternalIdentity[]
-  thumbnails          PersonThumbnail[]
-  fromRelationships   Relationship[] @relation("FromPerson")
-  toRelationships     Relationship[] @relation("ToPerson")
-  lifeEvents          LifeEvent[]
-  personNames         PersonName[]
-  researchTasks       ResearchTask[]
-  familiesAsParent1   Family[]       @relation("FamilyParent1")
-  familiesAsParent2   Family[]       @relation("FamilyParent2")
-  familiesAsChild     FamilyChild[]  @relation("FamilyChild")
-  cooccurrenceAsA     CooccurrenceEdge[] @relation("CooccurrencePersonA")
-  cooccurrenceAsB     CooccurrenceEdge[] @relation("CooccurrencePersonB")
+  externalIds               Json                     @default("{}")
+  createdAt                 DateTime                 @default(now())
+  updatedAt                 DateTime                 @updatedAt
+  user                      TreemichUser             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  externalIdentities        PersonExternalIdentity[]
+  thumbnails                PersonThumbnail[]
+  fromRelationships         Relationship[]           @relation("FromPerson")
+  toRelationships           Relationship[]           @relation("ToPerson")
+  lifeEvents                LifeEvent[]
+  personNames               PersonName[]
+  researchTasks             ResearchTask[]
+  familiesAsParent1         Family[]                 @relation("FamilyParent1")
+  familiesAsParent2         Family[]                 @relation("FamilyParent2")
+  familiesAsChild           FamilyChild[]            @relation("FamilyChild")
+  cooccurrenceAsA           CooccurrenceEdge[]       @relation("CooccurrencePersonA")
+  cooccurrenceAsB           CooccurrenceEdge[]       @relation("CooccurrencePersonB")
+  validationFindings        ValidationFinding[]      @relation("ValidationFindingPerson")
+  relatedValidationFindings ValidationFinding[]      @relation("ValidationFindingRelatedPerson")
 
   @@index([userId])
   @@index([userId, givenName])
@@ -229,7 +245,7 @@ model PersonExternalIdentity {
 }
 
 model PersonThumbnail {
-  id                       String                    @id @default(cuid())
+  id                       String                  @id @default(cuid())
   userId                   String
   personId                 String
   source                   PersonThumbnailSource
@@ -238,11 +254,11 @@ model PersonThumbnail {
   checksum                 String?
   sourceExternalIdentityId String?
   importedAt               DateTime?
-  createdAt                DateTime                  @default(now())
-  updatedAt                DateTime                  @updatedAt
-  user                     TreemichUser              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  person                   PersonProfile             @relation(fields: [personId], references: [id], onDelete: Cascade)
-  sourceExternalIdentity   PersonExternalIdentity?   @relation(fields: [sourceExternalIdentityId], references: [id], onDelete: SetNull)
+  createdAt                DateTime                @default(now())
+  updatedAt                DateTime                @updatedAt
+  user                     TreemichUser            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  person                   PersonProfile           @relation(fields: [personId], references: [id], onDelete: Cascade)
+  sourceExternalIdentity   PersonExternalIdentity? @relation(fields: [sourceExternalIdentityId], references: [id], onDelete: SetNull)
 
   @@index([userId, personId])
   @@index([sourceExternalIdentityId])
@@ -287,20 +303,21 @@ model ResearchTask {
 }
 
 model Relationship {
-  id         String           @id @default(cuid())
-  userId     String
-  fromPersonId String
-  toPersonId String
-  type       RelationshipType
+  id                 String              @id @default(cuid())
+  userId             String
+  fromPersonId       String
+  toPersonId         String
+  type               RelationshipType
   /// When set, this parent/child edge is derived from {@link Family} membership (not edited via DELETE /people/.../relationships).
-  familyId   String?
-  createdAt  DateTime         @default(now())
-  updatedAt  DateTime         @updatedAt
-  user       TreemichUser     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  fromPerson PersonProfile    @relation("FromPerson", fields: [fromPersonId], references: [id], onDelete: Cascade)
-  toPerson   PersonProfile    @relation("ToPerson", fields: [toPersonId], references: [id], onDelete: Cascade)
-  family     Family?          @relation(fields: [familyId], references: [id], onDelete: Cascade)
-  lifeEvents LifeEvent[]
+  familyId           String?
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  user               TreemichUser        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fromPerson         PersonProfile       @relation("FromPerson", fields: [fromPersonId], references: [id], onDelete: Cascade)
+  toPerson           PersonProfile       @relation("ToPerson", fields: [toPersonId], references: [id], onDelete: Cascade)
+  family             Family?             @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  lifeEvents         LifeEvent[]
+  validationFindings ValidationFinding[]
 
   @@unique([userId, fromPersonId, toPersonId, type])
   @@index([userId, fromPersonId])
@@ -311,21 +328,22 @@ model Relationship {
 
 /// Union of up to two parents plus children (FAM-style). Canonical for children in this union; parent/child graph edges with {@link Relationship#familyId} are derived.
 model Family {
-  id              String         @id @default(cuid())
-  userId          String
-  parent1PersonId String?
-  parent2PersonId String?
-  notes           String?
+  id                   String              @id @default(cuid())
+  userId               String
+  parent1PersonId      String?
+  parent2PersonId      String?
+  notes                String?
   /// Optional map for interchange (e.g. `{ "gedcomFam": "F12" }` from GEDCOM import for idempotent FAM rows).
-  externalIds     Json           @default("{}")
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
-  user            TreemichUser   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  parent1         PersonProfile? @relation("FamilyParent1", fields: [parent1PersonId], references: [id], onDelete: SetNull)
-  parent2         PersonProfile? @relation("FamilyParent2", fields: [parent2PersonId], references: [id], onDelete: SetNull)
-  children        FamilyChild[]
+  externalIds          Json                @default("{}")
+  createdAt            DateTime            @default(now())
+  updatedAt            DateTime            @updatedAt
+  user                 TreemichUser        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent1              PersonProfile?      @relation("FamilyParent1", fields: [parent1PersonId], references: [id], onDelete: SetNull)
+  parent2              PersonProfile?      @relation("FamilyParent2", fields: [parent2PersonId], references: [id], onDelete: SetNull)
+  children             FamilyChild[]
   derivedRelationships Relationship[]
-  lifeEvents      LifeEvent[]
+  lifeEvents           LifeEvent[]
+  validationFindings   ValidationFinding[]
 
   @@index([userId])
   @@index([userId, parent1PersonId])
@@ -347,7 +365,7 @@ model FamilyChild {
 }
 
 model Place {
-  id           String    @id @default(cuid())
+  id           String       @id @default(cuid())
   userId       String
   name         String
   addressLine1 String?
@@ -355,11 +373,11 @@ model Place {
   adminArea    String?
   postalCode   String?
   countryCode  String?
-  latitude     Decimal?  @db.Decimal(10, 7)
-  longitude    Decimal?  @db.Decimal(10, 7)
+  latitude     Decimal?     @db.Decimal(10, 7)
+  longitude    Decimal?     @db.Decimal(10, 7)
   notes        String?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
   user         TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
   lifeEvents   LifeEvent[]
 
@@ -368,31 +386,33 @@ model Place {
 }
 
 model LifeEvent {
-  id               String         @id @default(cuid())
-  userId           String
-  eventType        LifeEventType
-  /** Non-null display label when `eventType` is CUSTOM (required by API for CUSTOM). */
-  customLabel      String?
-  dateQualifier    DateQualifier  @default(EXACT)
-  year             Int?
-  month            Int?
-  day              Int?
-  endYear          Int?
-  endMonth         Int?
-  endDay           Int?
-  personProfileId  String?
-  relationshipId   String?
-  familyId         String?
-  placeId          String?
-  notes            String?
-  createdAt        DateTime       @default(now())
-  updatedAt        DateTime       @updatedAt
-  user             TreemichUser   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  personProfile    PersonProfile? @relation(fields: [personProfileId], references: [id], onDelete: Cascade)
-  relationship     Relationship?  @relation(fields: [relationshipId], references: [id], onDelete: Cascade)
-  family           Family?        @relation(fields: [familyId], references: [id], onDelete: Cascade)
-  place            Place?         @relation(fields: [placeId], references: [id], onDelete: SetNull)
-  citations        Citation[]
+  id              String         @id @default(cuid())
+  userId          String
+  eventType       LifeEventType
+  /**
+   * Non-null display label when `eventType` is CUSTOM (required by API for CUSTOM).
+   */
+  customLabel     String?
+  dateQualifier   DateQualifier  @default(EXACT)
+  year            Int?
+  month           Int?
+  day             Int?
+  endYear         Int?
+  endMonth        Int?
+  endDay          Int?
+  personProfileId String?
+  relationshipId  String?
+  familyId        String?
+  placeId         String?
+  notes           String?
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+  user            TreemichUser   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  personProfile   PersonProfile? @relation(fields: [personProfileId], references: [id], onDelete: Cascade)
+  relationship    Relationship?  @relation(fields: [relationshipId], references: [id], onDelete: Cascade)
+  family          Family?        @relation(fields: [familyId], references: [id], onDelete: Cascade)
+  place           Place?         @relation(fields: [placeId], references: [id], onDelete: SetNull)
+  citations       Citation[]
 
   @@index([userId, personProfileId])
   @@index([userId, relationshipId])
@@ -401,50 +421,50 @@ model LifeEvent {
 }
 
 model Repository {
-  id             String   @id @default(cuid())
-  userId         String
-  name           String
-  addressLine1   String?
-  url            String?
-  notes          String?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-  user           TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
-  sources        Source[]
+  id           String       @id @default(cuid())
+  userId       String
+  name         String
+  addressLine1 String?
+  url          String?
+  notes        String?
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  user         TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  sources      Source[]
 
   @@unique([userId, name])
   @@index([userId])
 }
 
 model Source {
-  id             String       @id @default(cuid())
-  userId         String
-  repositoryId   String?
-  title          String
-  author         String?
-  publication    String?
-  url            String?
-  notes          String?
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
-  user           TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
-  repository     Repository?  @relation(fields: [repositoryId], references: [id], onDelete: SetNull)
-  citations      Citation[]
+  id           String       @id @default(cuid())
+  userId       String
+  repositoryId String?
+  title        String
+  author       String?
+  publication  String?
+  url          String?
+  notes        String?
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  user         TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  repository   Repository?  @relation(fields: [repositoryId], references: [id], onDelete: SetNull)
+  citations    Citation[]
 
   @@index([userId])
   @@index([userId, repositoryId])
 }
 
 model Citation {
-  id          String    @id @default(cuid())
+  id          String       @id @default(cuid())
   userId      String
   sourceId    String
   lifeEventId String
   page        String?
   notes       String?
   citedAt     String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
   user        TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
   source      Source       @relation(fields: [sourceId], references: [id], onDelete: Restrict)
   lifeEvent   LifeEvent    @relation(fields: [lifeEventId], references: [id], onDelete: Cascade)
@@ -481,20 +501,54 @@ model MediaLink {
   user          TreemichUser        @relation(fields: [userId], references: [id], onDelete: Cascade)
   mediaObject   MediaObject         @relation(fields: [mediaObjectId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, mediaObjectId, targetType, targetId])
   @@index([userId, targetType, targetId])
   @@index([mediaObjectId])
 }
 
+model ValidationFinding {
+  id              String                    @id @default(cuid())
+  userId          String
+  code            String
+  severity        ValidationFindingSeverity
+  message         String
+  personId        String?
+  relationshipId  String?
+  relatedPersonId String?
+  familyId        String?
+  status          ValidationFindingStatus   @default(OPEN)
+  fingerprint     String
+  firstSeenAt     DateTime                  @default(now())
+  lastSeenAt      DateTime                  @default(now())
+  resolvedAt      DateTime?
+  dismissedAt     DateTime?
+  inProgressAt    DateTime?
+  metadata        Json                      @default("{}")
+  user            TreemichUser              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  person          PersonProfile?            @relation("ValidationFindingPerson", fields: [personId], references: [id], onDelete: SetNull)
+  relationship    Relationship?             @relation(fields: [relationshipId], references: [id], onDelete: SetNull)
+  relatedPerson   PersonProfile?            @relation("ValidationFindingRelatedPerson", fields: [relatedPersonId], references: [id], onDelete: SetNull)
+  family          Family?                   @relation(fields: [familyId], references: [id], onDelete: SetNull)
+
+  @@unique([userId, fingerprint])
+  @@index([userId, status])
+  @@index([userId, code])
+  @@index([userId, severity])
+  @@index([userId, personId])
+  @@index([userId, relationshipId])
+  @@index([userId, familyId])
+}
+
 model CooccurrenceSchedule {
-  id         String       @id @default(cuid())
-  userId     String       @unique
-  enabled    Boolean      @default(true)
-  intervalDays Int         @default(7)
-  nextRunAt  DateTime
-  lastRunAt  DateTime?
-  createdAt  DateTime     @default(now())
-  updatedAt  DateTime     @updatedAt
-  user       TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id           String       @id @default(cuid())
+  userId       String       @unique
+  enabled      Boolean      @default(true)
+  intervalDays Int          @default(7)
+  nextRunAt    DateTime
+  lastRunAt    DateTime?
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  user         TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([enabled, nextRunAt])
 }
@@ -518,23 +572,23 @@ model CooccurrenceJob {
 }
 
 model CooccurrenceEdge {
-  id                String       @id @default(cuid())
+  id                String                          @id @default(cuid())
   userId            String
   personAId         String
   personBId         String
   sourceProvider    PersonExternalIdentityProvider?
   sourceImportedAt  DateTime?
-  sourceMetadata    Json         @default("{}")
+  sourceMetadata    Json                            @default("{}")
   sharedPhotos      Int
   score             Float
   personAPhotoCount Int
   personBPhotoCount Int
   computedAt        DateTime
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
-  user              TreemichUser @relation(fields: [userId], references: [id], onDelete: Cascade)
-  personA           PersonProfile @relation("CooccurrencePersonA", fields: [personAId], references: [id], onDelete: Cascade)
-  personB           PersonProfile @relation("CooccurrencePersonB", fields: [personBId], references: [id], onDelete: Cascade)
+  createdAt         DateTime                        @default(now())
+  updatedAt         DateTime                        @updatedAt
+  user              TreemichUser                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  personA           PersonProfile                   @relation("CooccurrencePersonA", fields: [personAId], references: [id], onDelete: Cascade)
+  personB           PersonProfile                   @relation("CooccurrencePersonB", fields: [personBId], references: [id], onDelete: Cascade)
 
   @@unique([userId, personAId, personBId])
   @@index([userId])
@@ -551,46 +605,46 @@ model DataMigrationCheckpoint {
 }
 
 model GedcomImportJob {
-  id           String                @id @default(cuid())
-  userId       String
-  status       GedcomImportJobStatus @default(PENDING)
-  fileName     String                @default("import.ged")
-  byteSize     Int
+  id            String                @id @default(cuid())
+  userId        String
+  status        GedcomImportJobStatus @default(PENDING)
+  fileName      String                @default("import.ged")
+  byteSize      Int
   /// Raw UTF-8 payload (bounded by `TREEMICH_GEDCOM_IMPORT_MAX_BYTES` at upload).
-  gedcomUtf8   String                @db.Text
+  gedcomUtf8    String                @db.Text
   /// Client-supplied map of GEDCOM INDI xref (e.g. `@I1@` or `I1`) → Treemich PersonProfile id for this user.
-  indiMatches  Json                  @default("{}")
+  indiMatches   Json                  @default("{}")
   /// Options: dryRun, skipAlreadyImportedIndis, etc.
-  importOptions Json                 @default("{}")
-  startedAt    DateTime?
-  completedAt  DateTime?
-  errorMessage String?
+  importOptions Json                  @default("{}")
+  startedAt     DateTime?
+  completedAt   DateTime?
+  errorMessage  String?
   /// Structured parse/apply messages (truncated server-side).
-  lineLog      Json                  @default("[]")
+  lineLog       Json                  @default("[]")
   /// Counts and ids created (families, events, …).
-  summary      Json?
-  createdAt    DateTime              @default(now())
-  updatedAt    DateTime              @updatedAt
-  user         TreemichUser          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  summary       Json?
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+  user          TreemichUser          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
 }
 
 /// Async GEDCOM export (UTF-8 text stored when complete, capped like import max bytes).
 model GedcomExportJob {
-  id                        String                 @id @default(cuid())
+  id                        String                @id @default(cuid())
   userId                    String
-  status                    GedcomExportJobStatus  @default(PENDING)
-  redactLiving              Boolean                @default(false)
-  includeTreemichCustomTags Boolean                @default(true)
+  status                    GedcomExportJobStatus @default(PENDING)
+  redactLiving              Boolean               @default(false)
+  includeTreemichCustomTags Boolean               @default(true)
   byteSize                  Int?
-  gedcomUtf8                String?                @db.Text
+  gedcomUtf8                String?               @db.Text
   startedAt                 DateTime?
   completedAt               DateTime?
   errorMessage              String?
-  createdAt                 DateTime               @default(now())
-  updatedAt                 DateTime               @updatedAt
-  user                      TreemichUser           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt                 DateTime              @default(now())
+  updatedAt                 DateTime              @updatedAt
+  user                      TreemichUser          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -33,6 +33,7 @@ import { registerGraphLayoutPostRoute } from "./routes/graph-layout.post.js";
 import { registerImmichProviderRoutes } from "./routes/immich-provider.js";
 import { registerPeopleGetRoute } from "./routes/people.get.js";
 import { registerPeopleCooccurrenceGetRoute } from "./routes/people-cooccurrence.get.js";
+import { registerPersonDuplicateRoutes } from "./routes/person-duplicates.js";
 import { registerPeopleRelationshipsDeleteRoute } from "./routes/people-relationships.delete.js";
 import { registerPeopleRelationshipsPatchRoute } from "./routes/people-relationships.patch.js";
 import { registerPeopleLifeEventsRoutes } from "./routes/people-life-events.js";
@@ -224,6 +225,7 @@ export const buildApp = (options: BuildAppOptions = {}) => {
   app.register(registerGraphLayoutPostRoute);
   app.register(registerImmichProviderRoutes);
   app.register(registerPeopleGetRoute);
+  app.register(registerPersonDuplicateRoutes);
   app.register(registerPeopleCooccurrenceGetRoute);
   app.register(registerPeopleThumbnailGetRoute);
   app.register(registerPeopleRelationshipsPostRoute);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -43,6 +43,7 @@ import { registerPlacesMapGetRoute } from "./routes/places-map.get.js";
 import { registerPeopleRelationshipsPostRoute } from "./routes/people-relationships.post.js";
 import { registerPeopleThumbnailGetRoute } from "./routes/people-thumbnail.get.js";
 import { registerEvidenceRoutes } from "./routes/evidence.js";
+import { registerReportRoutes } from "./routes/reports.js";
 import { registerResearchTaskRoutes } from "./routes/research-tasks.js";
 import { registerRelationshipsGetRoute } from "./routes/relationships.get.js";
 import { registerRelationshipsLifeEventsRoutes } from "./routes/relationships-life-events.js";
@@ -241,6 +242,7 @@ export const buildApp = (options: BuildAppOptions = {}) => {
   app.register(registerPlacesMapGetRoute);
   app.register(registerResearchTaskRoutes);
   app.register(registerEvidenceRoutes);
+  app.register(registerReportRoutes);
   app.register(registerSearchGetRoute);
   app.register(registerTreeValidationGetRoute);
   app.register(registerValidationFindingRoutes);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -49,6 +49,7 @@ import { registerSearchGetRoute } from "./routes/search.get.js";
 import { registerTreeValidationGetRoute } from "./routes/tree-validation.get.js";
 import { registerUserPreferencesGetRoute } from "./routes/user-preferences.get.js";
 import { registerUserPreferencesPatchRoute } from "./routes/user-preferences.patch.js";
+import { registerValidationFindingRoutes } from "./routes/validation-findings.js";
 import { buildServices, registerServices, type AppServices } from "./services.js";
 
 type BuildAppOptions = {
@@ -240,6 +241,7 @@ export const buildApp = (options: BuildAppOptions = {}) => {
   app.register(registerEvidenceRoutes);
   app.register(registerSearchGetRoute);
   app.register(registerTreeValidationGetRoute);
+  app.register(registerValidationFindingRoutes);
   app.register(registerUserPreferencesGetRoute);
   app.register(registerUserPreferencesPatchRoute);
   app.register(registerExportAccountGetRoute);

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -127,7 +127,18 @@ const envSchema = z
     /** Max ZIP upload size for GEDCOM + media archive imports (default 100 MB). */
     TREEMICH_GEDCOM_MEDIA_MAX_BYTES: z.coerce.number().int().positive().optional(),
     /** Max individual media file size accepted from GEDCOM archive imports (default 50 MB). */
-    TREEMICH_GEDCOM_MEDIA_MAX_FILE_BYTES: z.coerce.number().int().positive().optional()
+    TREEMICH_GEDCOM_MEDIA_MAX_FILE_BYTES: z.coerce.number().int().positive().optional(),
+    /**
+     * When "false" / "0" / "no" / "off", disables synchronous structured report routes.
+     * Default when unset: enabled.
+     */
+    TREEMICH_REPORTS_ENABLED: z.string().optional(),
+    /** Operator report traversal depth cap. Effective cap is bounded by hard safety max. */
+    TREEMICH_REPORT_MAX_DEPTH: z.coerce.number().int().positive().optional(),
+    /** Max people a single report traversal may include before rejecting. */
+    TREEMICH_REPORT_MAX_PEOPLE: z.coerce.number().int().positive().optional(),
+    /** Reserved for future server-rendered PDF/export jobs. Default disabled. */
+    TREEMICH_REPORT_PDF_ENABLED: z.string().optional()
   })
   .superRefine((value, ctx) => {
     if (value.NODE_ENV === "production" && !value.WEB_ORIGIN) {
@@ -216,3 +227,23 @@ export const maxGedcomImportLines = (): number => env.TREEMICH_GEDCOM_IMPORT_MAX
 export const maxGedcomMediaArchiveBytes = (): number => env.TREEMICH_GEDCOM_MEDIA_MAX_BYTES ?? 100_000_000;
 
 export const maxGedcomMediaFileBytes = (): number => env.TREEMICH_GEDCOM_MEDIA_MAX_FILE_BYTES ?? 50_000_000;
+
+export const isReportsEnabled = (): boolean => {
+  const v = env.TREEMICH_REPORTS_ENABLED;
+  if (v == null || v === "") {
+    return true;
+  }
+  return !["0", "false", "no", "off"].includes(v.toLowerCase());
+};
+
+export const reportMaxDepth = (): number => Math.min(env.TREEMICH_REPORT_MAX_DEPTH ?? 6, 10);
+
+export const reportMaxPeople = (): number => env.TREEMICH_REPORT_MAX_PEOPLE ?? 1000;
+
+export const isReportPdfEnabled = (): boolean => {
+  const v = env.TREEMICH_REPORT_PDF_ENABLED;
+  if (v == null || v === "") {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(v.toLowerCase());
+};

--- a/apps/api/src/evidence/service.spec.ts
+++ b/apps/api/src/evidence/service.spec.ts
@@ -16,8 +16,12 @@ const mediaObjectCreateMock = vi.fn();
 const mediaObjectUpdateMock = vi.fn();
 const mediaObjectDeleteManyMock = vi.fn();
 const mediaLinkFindManyMock = vi.fn();
+const mediaLinkFindFirstMock = vi.fn();
 const mediaLinkCreateMock = vi.fn();
 const mediaLinkDeleteManyMock = vi.fn();
+const personProfileFindFirstMock = vi.fn();
+const lifeEventFindFirstMock = vi.fn();
+const familyFindFirstMock = vi.fn();
 const citationUpdateManyMock = vi.fn();
 const prismaTransactionMock = vi.fn();
 
@@ -46,9 +50,13 @@ vi.mock("../db/client.js", () => ({
     },
     mediaLink: {
       findMany: mediaLinkFindManyMock,
+      findFirst: mediaLinkFindFirstMock,
       create: mediaLinkCreateMock,
       deleteMany: mediaLinkDeleteManyMock
     },
+    personProfile: { findFirst: personProfileFindFirstMock },
+    lifeEvent: { findFirst: lifeEventFindFirstMock },
+    family: { findFirst: familyFindFirstMock },
     citation: {
       updateMany: citationUpdateManyMock
     },
@@ -265,6 +273,8 @@ describe("EvidenceService", () => {
       createdAt,
       updatedAt: createdAt
     });
+    sourceFindFirstMock.mockResolvedValueOnce({ id: "s9", userId: "u1" });
+    mediaLinkFindFirstMock.mockResolvedValueOnce(null);
     mediaLinkCreateMock.mockResolvedValueOnce({
       id: "lnk1",
       userId: "u1",
@@ -301,5 +311,51 @@ describe("EvidenceService", () => {
         notes: null
       }
     });
+  });
+
+  it("creates FAMILY media links only for owned families", async () => {
+    const createdAt = new Date("2024-04-02T00:00:00.000Z");
+    mediaObjectFindFirstMock.mockResolvedValueOnce({ id: "m1", userId: "u1" });
+    familyFindFirstMock.mockResolvedValueOnce({ id: "fam1", userId: "u1" });
+    mediaLinkFindFirstMock.mockResolvedValueOnce(null);
+    mediaLinkCreateMock.mockResolvedValueOnce({
+      id: "lnk-family",
+      userId: "u1",
+      mediaObjectId: "m1",
+      targetType: "FAMILY",
+      targetId: "fam1",
+      notes: null,
+      createdAt
+    });
+
+    const { EvidenceService } = await import("./service.js");
+    const svc = new EvidenceService();
+    const link = await svc.createMediaLink("u1", "m1", {
+      targetType: "FAMILY",
+      targetId: "fam1",
+      notes: null
+    });
+
+    expect(link.targetType).toBe("FAMILY");
+    expect(familyFindFirstMock).toHaveBeenCalledWith({
+      where: { id: "fam1", userId: "u1" },
+      select: { id: true }
+    });
+  });
+
+  it("rejects media links to missing targets", async () => {
+    mediaObjectFindFirstMock.mockResolvedValueOnce({ id: "m1", userId: "u1" });
+    familyFindFirstMock.mockResolvedValueOnce(null);
+
+    const { EvidenceService } = await import("./service.js");
+    const svc = new EvidenceService();
+    await expect(
+      svc.createMediaLink("u1", "m1", {
+        targetType: "FAMILY",
+        targetId: "foreign-family",
+        notes: null
+      })
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(mediaLinkCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/evidence/service.ts
+++ b/apps/api/src/evidence/service.ts
@@ -4,12 +4,14 @@ import type {
   CreateRepositoryBody,
   CreateSourceBody,
   MediaLinkRecord,
+  MediaLinkTargetType,
   MediaObjectRecord,
   PatchMediaObjectBody,
   PatchRepositoryBody,
   PatchSourceBody,
   RepositoryRecord,
-  SourceRecord
+  SourceRecord,
+  TargetMediaLinkRecord
 } from "@treemich/shared";
 import { prisma } from "../db/client.js";
 
@@ -88,7 +90,7 @@ const toMediaObjectJson = (row: {
 const toMediaLinkJson = (row: {
   id: string;
   mediaObjectId: string;
-  targetType: "PERSON_PROFILE" | "LIFE_EVENT" | "SOURCE";
+  targetType: MediaLinkTargetType;
   targetId: string;
   notes: string | null;
   createdAt: Date;
@@ -101,7 +103,39 @@ const toMediaLinkJson = (row: {
   createdAt: row.createdAt.toISOString()
 });
 
+const toTargetMediaLinkJson = (
+  row: Parameters<typeof toMediaLinkJson>[0] & { mediaObject: Parameters<typeof toMediaObjectJson>[0] }
+): TargetMediaLinkRecord => ({
+  ...toMediaLinkJson(row),
+  mediaObject: toMediaObjectJson(row.mediaObject)
+});
+
+const notFound = (message: string) => {
+  const err = new Error(message);
+  (err as Error & { statusCode: number }).statusCode = 404;
+  return err;
+};
+
 export class EvidenceService {
+  private async assertTargetExists(
+    userId: string,
+    targetType: MediaLinkTargetType,
+    targetId: string
+  ): Promise<void> {
+    const where = { id: targetId, userId };
+    const exists =
+      targetType === "PERSON_PROFILE"
+        ? await prisma.personProfile.findFirst({ where, select: { id: true } })
+        : targetType === "LIFE_EVENT"
+          ? await prisma.lifeEvent.findFirst({ where, select: { id: true } })
+          : targetType === "SOURCE"
+            ? await prisma.source.findFirst({ where, select: { id: true } })
+            : await prisma.family.findFirst({ where, select: { id: true } });
+    if (!exists) {
+      throw notFound("Media link target not found");
+    }
+  }
+
   async listRepositories(userId: string): Promise<RepositoryRecord[]> {
     const rows = await prisma.repository.findMany({
       where: { userId },
@@ -360,6 +394,21 @@ export class EvidenceService {
     return rows.map(toMediaLinkJson);
   }
 
+  async listMediaLinksForTarget(
+    userId: string,
+    targetType: MediaLinkTargetType,
+    targetId: string
+  ): Promise<TargetMediaLinkRecord[]> {
+    const trimmedTargetId = targetId.trim();
+    await this.assertTargetExists(userId, targetType, trimmedTargetId);
+    const rows = await prisma.mediaLink.findMany({
+      where: { userId, targetType, targetId: trimmedTargetId },
+      include: { mediaObject: true },
+      orderBy: { createdAt: "desc" }
+    });
+    return rows.map(toTargetMediaLinkJson);
+  }
+
   async createMediaLink(
     userId: string,
     mediaObjectId: string,
@@ -367,16 +416,27 @@ export class EvidenceService {
   ): Promise<MediaLinkRecord> {
     const parent = await prisma.mediaObject.findFirst({ where: { id: mediaObjectId, userId } });
     if (!parent) {
-      const err = new Error("Media object not found");
-      (err as Error & { statusCode: number }).statusCode = 404;
-      throw err;
+      throw notFound("Media object not found");
+    }
+    const targetId = body.targetId.trim();
+    await this.assertTargetExists(userId, body.targetType, targetId);
+    const existing = await prisma.mediaLink.findFirst({
+      where: {
+        userId,
+        mediaObjectId,
+        targetType: body.targetType,
+        targetId
+      }
+    });
+    if (existing) {
+      return toMediaLinkJson(existing);
     }
     const created = await prisma.mediaLink.create({
       data: {
         userId,
         mediaObjectId,
         targetType: body.targetType,
-        targetId: body.targetId.trim(),
+        targetId,
         notes: body.notes?.trim() ? body.notes.trim() : null
       }
     });

--- a/apps/api/src/gedcom/importRunner.ts
+++ b/apps/api/src/gedcom/importRunner.ts
@@ -647,7 +647,7 @@ export async function processGedcomImportJob(jobId: string, services: AppService
 
   const linkObjePointers = async (
     pointers: string[],
-    targetType: "PERSON_PROFILE" | "LIFE_EVENT" | "SOURCE",
+    targetType: "PERSON_PROFILE" | "LIFE_EVENT" | "SOURCE" | "FAMILY",
     targetId: string,
     context: string
   ) => {
@@ -1081,11 +1081,20 @@ export async function processGedcomImportJob(jobId: string, services: AppService
         .filter((ch) => ch[0]?.tag === "OBJE")
         .flatMap((ch) => objePointersFromChunk(ch, 1));
       if (familyLevelObjePointers.length > 0) {
-        pushLog(lineLog, {
-          severity: "warn",
-          lineNo: block.startLineNo,
-          message: `FAM ${fam.xref}: family-level OBJE pointers are parsed but skipped; Phase 5 links media to person profiles, life events, and sources`
-        });
+        if (treemichFamilyId || dryRun) {
+          await linkObjePointers(
+            familyLevelObjePointers,
+            "FAMILY",
+            treemichFamilyId ?? `dry-run-fam-${fam.xref}`,
+            `FAM ${fam.xref}`
+          );
+        } else {
+          pushLog(lineLog, {
+            severity: "warn",
+            lineNo: block.startLineNo,
+            message: `FAM ${fam.xref}: family-level OBJE pointers could not be linked because no Treemich family was resolved`
+          });
+        }
       }
 
       for (const ch of chunkByLevel1(block.lines)) {

--- a/apps/api/src/gedcom/writer.spec.ts
+++ b/apps/api/src/gedcom/writer.spec.ts
@@ -268,6 +268,69 @@ describe("buildGedcomDocument", () => {
     expect(norm).toContain("1 OBJE @O0002@");
   });
 
+  it("emits family media as root FAM OBJE before family events", () => {
+    const { gedcomUtf8 } = buildGedcomDocument({
+      personProfiles: [
+        {
+          id: "pp-a",
+          gender: "MALE",
+          givenName: "A",
+          surname: "One",
+          displayNameOverride: null,
+          externalIds: {}
+        },
+        {
+          id: "pp-b",
+          gender: "FEMALE",
+          givenName: "B",
+          surname: "Two",
+          displayNameOverride: null,
+          externalIds: {}
+        }
+      ],
+      relationships: [],
+      families: [
+        {
+          id: "fam-1",
+          parent1PersonId: "pp-a",
+          parent2PersonId: "pp-b",
+          notes: "Family notes",
+          externalIds: {},
+          children: []
+        }
+      ],
+      lifeEvents: [
+        {
+          id: "fam-event",
+          eventType: "RESIDENCE",
+          customLabel: null,
+          dateQualifier: "EXACT",
+          year: 1901,
+          month: null,
+          day: null,
+          endYear: null,
+          endMonth: null,
+          endDay: null,
+          personId: null,
+          relationshipId: null,
+          familyId: "fam-1",
+          notes: null,
+          place: null,
+          citations: []
+        }
+      ],
+      personNames: [],
+      repositories: [],
+      sources: [],
+      mediaObjects: [{ id: "m-family", storageUrl: "family.jpg", mimeType: "image/jpeg", title: "Family" }],
+      mediaLinks: [{ mediaObjectId: "m-family", targetType: "FAMILY", targetId: "fam-1" }]
+    });
+
+    const norm = normalizeGedcomForTest(gedcomUtf8);
+    expect(norm).toContain("1 OBJE @O0001@");
+    expect(norm.indexOf("1 OBJE @O0001@")).toBeLessThan(norm.indexOf("1 RESI"));
+  });
+
   it("uses externalIds.gedcomFam as stable FAM xref when valid", () => {
     const { gedcomUtf8, xrefs } = buildGedcomDocument(
       {

--- a/apps/api/src/gedcom/writer.ts
+++ b/apps/api/src/gedcom/writer.ts
@@ -415,6 +415,22 @@ export function buildGedcomDocument(
     xrefs.obje[xref] = { mediaObjectId: m.id };
   });
 
+  const mediaForTarget = (targetType: string, targetId: string): string[] => {
+    const xrefsOut: string[] = [];
+    for (const link of input.mediaLinks) {
+      if (link.targetType !== targetType || link.targetId !== targetId) {
+        continue;
+      }
+      const ox = mediaIdToXref.get(link.mediaObjectId);
+      if (ox) {
+        xrefsOut.push(ox);
+      }
+    }
+    return [...new Set(xrefsOut)].sort();
+  };
+
+  const mediaForFamily = (familyId: string): string[] => mediaForTarget("FAMILY", familyId);
+
   /** family prisma id → FAM xref */
   const familyIdToXref = new Map<string, string>();
   const familiesSorted = [...input.families].sort((a, b) => a.id.localeCompare(b.id));
@@ -556,6 +572,9 @@ export function buildGedcomDocument(
     if (f.notes?.trim()) {
       lines.push(line(1, "NOTE", f.notes.trim()));
     }
+    for (const ox of mediaForFamily(f.id)) {
+      lines.push(line(1, "OBJE", `@${ox}@`));
+    }
   }
 
   for (const pairKey of syntheticPairs) {
@@ -625,47 +644,11 @@ export function buildGedcomDocument(
     }
   };
 
-  const mediaForLifeEvent = (lifeEventId: string): string[] => {
-    const xrefsOut: string[] = [];
-    for (const link of input.mediaLinks) {
-      if (link.targetType !== "LIFE_EVENT" || link.targetId !== lifeEventId) {
-        continue;
-      }
-      const ox = mediaIdToXref.get(link.mediaObjectId);
-      if (ox) {
-        xrefsOut.push(ox);
-      }
-    }
-    return [...new Set(xrefsOut)].sort();
-  };
+  const mediaForLifeEvent = (lifeEventId: string): string[] => mediaForTarget("LIFE_EVENT", lifeEventId);
 
-  const mediaForPersonProfile = (profileId: string): string[] => {
-    const xrefsOut: string[] = [];
-    for (const link of input.mediaLinks) {
-      if (link.targetType !== "PERSON_PROFILE" || link.targetId !== profileId) {
-        continue;
-      }
-      const ox = mediaIdToXref.get(link.mediaObjectId);
-      if (ox) {
-        xrefsOut.push(ox);
-      }
-    }
-    return [...new Set(xrefsOut)].sort();
-  };
+  const mediaForPersonProfile = (profileId: string): string[] => mediaForTarget("PERSON_PROFILE", profileId);
 
-  const mediaForSource = (sourceId: string): string[] => {
-    const xrefsOut: string[] = [];
-    for (const link of input.mediaLinks) {
-      if (link.targetType !== "SOURCE" || link.targetId !== sourceId) {
-        continue;
-      }
-      const ox = mediaIdToXref.get(link.mediaObjectId);
-      if (ox) {
-        xrefsOut.push(ox);
-      }
-    }
-    return [...new Set(xrefsOut)].sort();
-  };
+  const mediaForSource = (sourceId: string): string[] => mediaForTarget("SOURCE", sourceId);
 
   /** MARR / DIV and other events scoped to relationship */
   for (const e of input.lifeEvents) {

--- a/apps/api/src/personDuplicates/service.spec.ts
+++ b/apps/api/src/personDuplicates/service.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  candidateFindFirst: vi.fn(),
+  candidateUpdate: vi.fn()
+}));
+
+vi.mock("../db/client.js", () => ({
+  prisma: {
+    personDuplicateCandidate: {
+      findFirst: mocks.candidateFindFirst,
+      update: mocks.candidateUpdate
+    }
+  }
+}));
+
+const candidateRow = {
+  id: "dup-1",
+  userId: "user-1",
+  personAId: "p1",
+  personBId: "p2",
+  score: 85,
+  reasons: [{ code: "name", label: "Same full name", weight: 45 }],
+  status: "PENDING",
+  dismissedAt: null,
+  mergedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  personA: {
+    id: "p1",
+    displayNameOverride: null,
+    givenName: "Alex",
+    surname: "Smith",
+    externalIdentities: [],
+    lifeEvents: []
+  },
+  personB: {
+    id: "p2",
+    displayNameOverride: null,
+    givenName: "Alexander",
+    surname: "Smith",
+    externalIdentities: [],
+    lifeEvents: []
+  }
+};
+
+describe("PersonDuplicateService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects merging a person into itself before touching the database", async () => {
+    const { PersonDuplicateService } = await import("./service.js");
+    await expect(
+      new PersonDuplicateService().mergePeople("user-1", "dup-1", "p1", "p1")
+    ).rejects.toMatchObject({
+      statusCode: 400
+    });
+    expect(mocks.candidateFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("updates candidate review status and returns enriched candidate", async () => {
+    mocks.candidateFindFirst.mockResolvedValueOnce({ id: "dup-1", userId: "user-1" }).mockResolvedValueOnce({
+      ...candidateRow,
+      status: "DISMISSED",
+      dismissedAt: new Date("2026-01-02T00:00:00.000Z")
+    });
+    mocks.candidateUpdate.mockResolvedValueOnce({ id: "dup-1" });
+
+    const { PersonDuplicateService } = await import("./service.js");
+    const result = await new PersonDuplicateService().updateStatus("user-1", "dup-1", "DISMISSED");
+
+    expect(mocks.candidateUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "dup-1" },
+        data: expect.objectContaining({ status: "DISMISSED" })
+      })
+    );
+    expect(result.status).toBe("DISMISSED");
+    expect(result.personA.label).toBe("Alex Smith");
+  });
+});

--- a/apps/api/src/personDuplicates/service.ts
+++ b/apps/api/src/personDuplicates/service.ts
@@ -10,8 +10,6 @@ import type {
 import { formatPersonNameDisplay } from "@treemich/shared";
 import { prisma } from "../db/client.js";
 
-type DbClient = Prisma.TransactionClient | typeof prisma;
-
 type CandidateRow = Prisma.PersonDuplicateCandidateGetPayload<{
   include: {
     personA: {

--- a/apps/api/src/personDuplicates/service.ts
+++ b/apps/api/src/personDuplicates/service.ts
@@ -1,0 +1,892 @@
+import type { PersonDuplicateCandidateStatus, Prisma } from "@prisma/client";
+import type {
+  PersonDuplicateCandidateRecord,
+  PersonDuplicateListQuery,
+  PersonDuplicateReason,
+  PersonDuplicateRecomputeResponse,
+  PersonDuplicateSummary,
+  PersonMergeResult
+} from "@treemich/shared";
+import { formatPersonNameDisplay } from "@treemich/shared";
+import { prisma } from "../db/client.js";
+
+type DbClient = Prisma.TransactionClient | typeof prisma;
+
+type CandidateRow = Prisma.PersonDuplicateCandidateGetPayload<{
+  include: {
+    personA: {
+      include: {
+        externalIdentities: true;
+        lifeEvents: true;
+      };
+    };
+    personB: {
+      include: {
+        externalIdentities: true;
+        lifeEvents: true;
+      };
+    };
+  };
+}>;
+
+type DetectionPerson = Prisma.PersonProfileGetPayload<{
+  include: {
+    personNames: true;
+    externalIdentities: true;
+    lifeEvents: true;
+  };
+}>;
+
+const candidateInclude = {
+  personA: {
+    include: {
+      externalIdentities: true,
+      lifeEvents: { where: { eventType: { in: ["BIRTH", "DEATH"] } } }
+    }
+  },
+  personB: {
+    include: {
+      externalIdentities: true,
+      lifeEvents: { where: { eventType: { in: ["BIRTH", "DEATH"] } } }
+    }
+  }
+} as const satisfies Prisma.PersonDuplicateCandidateInclude;
+
+const httpError = (statusCode: number, message: string) => {
+  const err = new Error(message);
+  (err as Error & { statusCode: number }).statusCode = statusCode;
+  return err;
+};
+
+const toIsoOrNull = (value?: Date | null) => value?.toISOString() ?? null;
+
+const normalizeText = (value: string | null | undefined) =>
+  value
+    ?.normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{L}\p{N}\s'-]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLocaleLowerCase() ?? "";
+
+const dateValue = (event: { year: number | null; month: number | null; day: number | null }) => {
+  if (event.year == null) {
+    return null;
+  }
+  const month = event.month == null ? "" : `-${String(event.month).padStart(2, "0")}`;
+  const day = event.day == null ? "" : `-${String(event.day).padStart(2, "0")}`;
+  return `${String(event.year).padStart(4, "0")}${month}${day}`;
+};
+
+const vital = (person: {
+  lifeEvents: Array<{ eventType: string; year: number | null; month: number | null; day: number | null }>;
+}) => ({
+  birth: dateValue(
+    person.lifeEvents.find((event) => event.eventType === "BIRTH") ?? { year: null, month: null, day: null }
+  ),
+  death: dateValue(
+    person.lifeEvents.find((event) => event.eventType === "DEATH") ?? { year: null, month: null, day: null }
+  )
+});
+
+const displayName = (person: {
+  id: string;
+  displayNameOverride: string | null;
+  givenName: string | null;
+  surname: string | null;
+}) =>
+  person.displayNameOverride?.trim() ||
+  formatPersonNameDisplay({
+    givenName: person.givenName,
+    surname: person.surname
+  }) ||
+  `Person ${person.id.slice(0, 8)}`;
+
+const personSummary = (person: CandidateRow["personA"]): PersonDuplicateSummary => {
+  const dates = vital(person);
+  return {
+    id: person.id,
+    label: displayName(person),
+    givenName: person.givenName,
+    surname: person.surname,
+    birthDate: dates.birth,
+    deathDate: dates.death,
+    externalIdentityCount: person.externalIdentities.length
+  };
+};
+
+const parseReasons = (value: unknown): PersonDuplicateReason[] =>
+  Array.isArray(value)
+    ? value
+        .filter((item): item is PersonDuplicateReason => {
+          if (!item || typeof item !== "object") {
+            return false;
+          }
+          const candidate = item as Partial<PersonDuplicateReason>;
+          return typeof candidate.code === "string" && typeof candidate.label === "string";
+        })
+        .map((item) => ({
+          code: item.code,
+          label: item.label,
+          detail: item.detail,
+          weight: typeof item.weight === "number" ? item.weight : 0
+        }))
+    : [];
+
+const toRecord = (row: CandidateRow): PersonDuplicateCandidateRecord => ({
+  id: row.id,
+  personAId: row.personAId,
+  personBId: row.personBId,
+  score: row.score,
+  reasons: parseReasons(row.reasons),
+  status: row.status,
+  dismissedAt: toIsoOrNull(row.dismissedAt),
+  mergedAt: toIsoOrNull(row.mergedAt),
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  personA: personSummary(row.personA),
+  personB: personSummary(row.personB)
+});
+
+const orderedPair = (left: string, right: string) =>
+  left < right ? ([left, right] as const) : ([right, left] as const);
+
+const increment = (counts: Record<string, number>, key: string, amount: number) => {
+  counts[key] = (counts[key] ?? 0) + amount;
+};
+
+export class PersonDuplicateService {
+  async list(
+    userId: string,
+    query: PersonDuplicateListQuery = {}
+  ): Promise<PersonDuplicateCandidateRecord[]> {
+    const rows = await prisma.personDuplicateCandidate.findMany({
+      where: {
+        userId,
+        ...(query.status ? { status: query.status as PersonDuplicateCandidateStatus } : {})
+      },
+      include: candidateInclude,
+      orderBy: [{ status: "asc" }, { score: "desc" }, { updatedAt: "desc" }, { id: "asc" }],
+      take: query.limit ?? 50,
+      skip: query.offset ?? 0
+    });
+    return rows.map(toRecord);
+  }
+
+  async recomputeCandidates(userId: string): Promise<PersonDuplicateRecomputeResponse> {
+    const people = await prisma.personProfile.findMany({
+      where: { userId },
+      include: {
+        personNames: true,
+        externalIdentities: true,
+        lifeEvents: { where: { eventType: { in: ["BIRTH", "DEATH"] } } }
+      },
+      orderBy: [{ surname: "asc" }, { givenName: "asc" }, { id: "asc" }]
+    });
+    const [relationships, families, cooccurrenceEdges] = await Promise.all([
+      prisma.relationship.findMany({
+        where: { userId },
+        select: { fromPersonId: true, toPersonId: true, type: true }
+      }),
+      prisma.family.findMany({
+        where: { userId },
+        include: { children: true }
+      }),
+      prisma.cooccurrenceEdge.findMany({
+        where: { userId, score: { gte: 0.7 } },
+        select: { personAId: true, personBId: true, sharedPhotos: true, score: true }
+      })
+    ]);
+
+    const candidates = this.detectCandidates(people, relationships, families, cooccurrenceEdges);
+    const now = new Date();
+    const summary = { created: 0, updated: 0, preservedDismissed: 0, pending: 0 };
+
+    for (const candidate of candidates) {
+      const [personAId, personBId] = orderedPair(candidate.personAId, candidate.personBId);
+      const existing = await prisma.personDuplicateCandidate.findUnique({
+        where: { userId_personAId_personBId: { userId, personAId, personBId } }
+      });
+      if (existing?.status === "DISMISSED" || existing?.status === "MERGED") {
+        summary.preservedDismissed += existing.status === "DISMISSED" ? 1 : 0;
+        continue;
+      }
+      if (existing) {
+        await prisma.personDuplicateCandidate.update({
+          where: { id: existing.id },
+          data: {
+            score: candidate.score,
+            reasons: candidate.reasons as Prisma.InputJsonValue,
+            status: "PENDING",
+            dismissedAt: null
+          }
+        });
+        summary.updated += 1;
+      } else {
+        await prisma.personDuplicateCandidate.create({
+          data: {
+            userId,
+            personAId,
+            personBId,
+            score: candidate.score,
+            reasons: candidate.reasons as Prisma.InputJsonValue,
+            createdAt: now
+          }
+        });
+        summary.created += 1;
+      }
+    }
+
+    summary.pending = await prisma.personDuplicateCandidate.count({ where: { userId, status: "PENDING" } });
+    return {
+      candidates: await this.list(userId, { status: "PENDING", limit: 50 }),
+      summary
+    };
+  }
+
+  async updateStatus(
+    userId: string,
+    candidateId: string,
+    status: "PENDING" | "DISMISSED"
+  ): Promise<PersonDuplicateCandidateRecord> {
+    const existing = await prisma.personDuplicateCandidate.findFirst({ where: { id: candidateId, userId } });
+    if (!existing) {
+      throw httpError(404, "Duplicate candidate not found");
+    }
+    const now = new Date();
+    await prisma.personDuplicateCandidate.update({
+      where: { id: candidateId },
+      data: {
+        status,
+        dismissedAt: status === "DISMISSED" ? now : null
+      }
+    });
+    return this.get(userId, candidateId);
+  }
+
+  async mergePeople(
+    userId: string,
+    candidateId: string,
+    canonicalPersonId: string,
+    duplicatePersonId: string
+  ): Promise<PersonMergeResult> {
+    if (canonicalPersonId === duplicatePersonId) {
+      throw httpError(400, "Cannot merge a person into itself");
+    }
+
+    const counts: Record<string, number> = {};
+    const warnings: string[] = [];
+    let auditId = "";
+
+    await prisma.$transaction(async (tx) => {
+      const candidate = await tx.personDuplicateCandidate.findFirst({ where: { id: candidateId, userId } });
+      if (!candidate) {
+        throw httpError(404, "Duplicate candidate not found");
+      }
+      if (candidate.status !== "PENDING") {
+        throw httpError(409, "Duplicate candidate is not pending");
+      }
+      const pair = new Set([candidate.personAId, candidate.personBId]);
+      if (!pair.has(canonicalPersonId) || !pair.has(duplicatePersonId)) {
+        throw httpError(400, "Merge people must match the duplicate candidate pair");
+      }
+
+      const [canonical, duplicate] = await Promise.all([
+        tx.personProfile.findFirst({ where: { id: canonicalPersonId, userId } }),
+        tx.personProfile.findFirst({ where: { id: duplicatePersonId, userId } })
+      ]);
+      if (!canonical || !duplicate) {
+        throw httpError(404, "Person not found");
+      }
+
+      const mergedExternalIds = {
+        ...this.jsonObject(duplicate.externalIds),
+        ...this.jsonObject(canonical.externalIds)
+      };
+      await tx.personProfile.update({
+        where: { id: canonicalPersonId },
+        data: { externalIds: mergedExternalIds as Prisma.InputJsonValue }
+      });
+
+      await this.moveExternalIdentities(tx, userId, duplicatePersonId, canonicalPersonId, counts);
+      await this.movePersonNames(tx, userId, duplicatePersonId, canonicalPersonId, counts);
+
+      const thumbnails = await tx.personThumbnail.updateMany({
+        where: { userId, personId: duplicatePersonId },
+        data: { personId: canonicalPersonId }
+      });
+      increment(counts, "personThumbnails", thumbnails.count);
+
+      const tasks = await tx.researchTask.updateMany({
+        where: { userId, personId: duplicatePersonId },
+        data: { personId: canonicalPersonId }
+      });
+      increment(counts, "researchTasks", tasks.count);
+
+      const events = await tx.lifeEvent.updateMany({
+        where: { userId, personProfileId: duplicatePersonId },
+        data: { personProfileId: canonicalPersonId }
+      });
+      increment(counts, "lifeEvents", events.count);
+
+      await this.movePersonMediaLinks(tx, userId, duplicatePersonId, canonicalPersonId, counts);
+      await this.moveValidationFindings(tx, userId, duplicatePersonId, canonicalPersonId, counts);
+      const affectedFamilyIds = await this.mergeFamilies(
+        tx,
+        userId,
+        duplicatePersonId,
+        canonicalPersonId,
+        counts,
+        warnings
+      );
+      await this.mergeRelationships(
+        tx,
+        userId,
+        duplicatePersonId,
+        canonicalPersonId,
+        affectedFamilyIds,
+        counts
+      );
+      await this.rebuildFamilyEdges(tx, userId, affectedFamilyIds, counts);
+      await this.mergeCooccurrenceEdges(tx, userId, duplicatePersonId, canonicalPersonId, counts);
+
+      await tx.personDuplicateCandidate.updateMany({
+        where: {
+          userId,
+          OR: [
+            { personAId: duplicatePersonId, personBId: canonicalPersonId },
+            { personAId: canonicalPersonId, personBId: duplicatePersonId }
+          ]
+        },
+        data: { status: "MERGED", mergedAt: new Date() }
+      });
+      const audit = await tx.personMergeAudit.create({
+        data: {
+          userId,
+          candidateId,
+          canonicalPersonId,
+          duplicatePersonId,
+          changedCounts: counts as Prisma.InputJsonValue,
+          warnings: warnings as Prisma.InputJsonValue,
+          externalIdentityPolicy:
+            "Moved distinct external identities to canonical person; duplicate provider tuples were deduped.",
+          metadata: { canonicalKeptProfileFields: true } as Prisma.InputJsonValue
+        }
+      });
+      auditId = audit.id;
+
+      await tx.personProfile.delete({ where: { id: duplicatePersonId } });
+      increment(counts, "personProfilesDeleted", 1);
+    });
+
+    const candidate = await this.get(userId, candidateId);
+    return {
+      candidate,
+      auditId,
+      canonicalPersonId,
+      duplicatePersonId,
+      changedCounts: counts,
+      warnings
+    };
+  }
+
+  private async get(userId: string, candidateId: string): Promise<PersonDuplicateCandidateRecord> {
+    const row = await prisma.personDuplicateCandidate.findFirst({
+      where: { id: candidateId, userId },
+      include: candidateInclude
+    });
+    if (!row) {
+      throw httpError(404, "Duplicate candidate not found");
+    }
+    return toRecord(row);
+  }
+
+  private detectCandidates(
+    people: DetectionPerson[],
+    relationships: Array<{ fromPersonId: string; toPersonId: string; type: string }>,
+    families: Array<{
+      parent1PersonId: string | null;
+      parent2PersonId: string | null;
+      children: Array<{ childPersonId: string | null }>;
+    }>,
+    cooccurrenceEdges: Array<{ personAId: string; personBId: string; sharedPhotos: number; score: number }>
+  ) {
+    const familySignals = this.familySignalMap(relationships, families);
+    const cooccurrence = new Map(
+      cooccurrenceEdges.map((edge) => [`${edge.personAId}:${edge.personBId}`, edge])
+    );
+    const candidates = new Map<
+      string,
+      { personAId: string; personBId: string; score: number; reasons: PersonDuplicateReason[] }
+    >();
+
+    for (let leftIndex = 0; leftIndex < people.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < people.length; rightIndex += 1) {
+        const left = people[leftIndex]!;
+        const right = people[rightIndex]!;
+        const reasons = this.scorePair(left, right, familySignals, cooccurrence);
+        const score = reasons.reduce((sum, reason) => sum + reason.weight, 0);
+        const hasStrongReason = reasons.some(
+          (reason) => reason.code !== "cooccurrence" && reason.weight >= 25
+        );
+        if (score < 50 || !hasStrongReason) {
+          continue;
+        }
+        const [personAId, personBId] = orderedPair(left.id, right.id);
+        candidates.set(`${personAId}:${personBId}`, {
+          personAId,
+          personBId,
+          score: Math.min(100, Math.round(score)),
+          reasons
+        });
+      }
+    }
+
+    return [...candidates.values()].sort((left, right) => right.score - left.score);
+  }
+
+  private scorePair(
+    left: DetectionPerson,
+    right: DetectionPerson,
+    familySignals: Map<string, Set<string>>,
+    cooccurrence: Map<string, { sharedPhotos: number; score: number }>
+  ): PersonDuplicateReason[] {
+    const reasons: PersonDuplicateReason[] = [];
+    const leftNames = this.nameTokens(left);
+    const rightNames = this.nameTokens(right);
+    const sharedNames = [...leftNames.full].filter((name) => rightNames.full.has(name));
+    if (sharedNames.length > 0) {
+      reasons.push({ code: "name", label: "Same full name", detail: sharedNames[0], weight: 45 });
+    } else if (
+      leftNames.surnames.size > 0 &&
+      [...leftNames.surnames].some((name) => rightNames.surnames.has(name))
+    ) {
+      const leftInitial = [...leftNames.given][0]?.slice(0, 1);
+      const rightInitial = [...rightNames.given][0]?.slice(0, 1);
+      reasons.push({
+        code: "name",
+        label: "Shared surname",
+        detail: leftInitial && leftInitial === rightInitial ? "Given-name initials also match" : undefined,
+        weight: leftInitial && leftInitial === rightInitial ? 35 : 22
+      });
+    }
+
+    const leftVital = vital(left);
+    const rightVital = vital(right);
+    if (leftVital.birth && rightVital.birth && leftVital.birth === rightVital.birth) {
+      reasons.push({ code: "vital", label: "Same birth date", detail: leftVital.birth, weight: 35 });
+    } else if (
+      leftVital.birth?.slice(0, 4) &&
+      leftVital.birth.slice(0, 4) === rightVital.birth?.slice(0, 4)
+    ) {
+      reasons.push({
+        code: "vital",
+        label: "Same birth year",
+        detail: leftVital.birth.slice(0, 4),
+        weight: 20
+      });
+    }
+    if (leftVital.death && rightVital.death && leftVital.death === rightVital.death) {
+      reasons.push({ code: "vital", label: "Same death date", detail: leftVital.death, weight: 20 });
+    }
+
+    const sharedFamilySignals = [...(familySignals.get(left.id) ?? [])].filter((signal) =>
+      familySignals.get(right.id)?.has(signal)
+    );
+    if (sharedFamilySignals.length > 0) {
+      reasons.push({
+        code: "family",
+        label: "Close family overlap",
+        detail: sharedFamilySignals.slice(0, 3).join(", "),
+        weight: 30
+      });
+    }
+
+    const [personAId, personBId] = orderedPair(left.id, right.id);
+    const edge = cooccurrence.get(`${personAId}:${personBId}`);
+    if (edge) {
+      reasons.push({
+        code: "cooccurrence",
+        label: "Strong photo co-occurrence",
+        detail: `${edge.sharedPhotos} shared photos`,
+        weight: 10
+      });
+    }
+
+    if (left.externalIdentities.length > 0 && right.externalIdentities.length > 0) {
+      reasons.push({
+        code: "externalIdentity",
+        label: "Both people have external identities",
+        detail: "Merge preserves distinct identities and dedupes identical provider tuples",
+        weight: 0
+      });
+    }
+
+    return reasons;
+  }
+
+  private nameTokens(person: DetectionPerson) {
+    const full = new Set<string>();
+    const surnames = new Set<string>();
+    const given = new Set<string>();
+    const add = (first: string | null | undefined, last: string | null | undefined) => {
+      const normalizedFirst = normalizeText(first);
+      const normalizedLast = normalizeText(last);
+      if (normalizedFirst) {
+        given.add(normalizedFirst);
+      }
+      if (normalizedLast) {
+        surnames.add(normalizedLast);
+      }
+      const joined = [normalizedFirst, normalizedLast].filter(Boolean).join(" ");
+      if (joined) {
+        full.add(joined);
+      }
+    };
+    add(person.givenName, person.surname);
+    for (const name of person.personNames) {
+      add(name.givenName, name.surname);
+    }
+    for (const nickname of normalizeText(person.nicknames)
+      .split(/\s*,\s*/)
+      .filter(Boolean)) {
+      given.add(nickname);
+    }
+    return { full, surnames, given };
+  }
+
+  private familySignalMap(
+    relationships: Array<{ fromPersonId: string; toPersonId: string; type: string }>,
+    families: Array<{
+      parent1PersonId: string | null;
+      parent2PersonId: string | null;
+      children: Array<{ childPersonId: string | null }>;
+    }>
+  ) {
+    const signals = new Map<string, Set<string>>();
+    const add = (personId: string | null | undefined, signal: string) => {
+      if (!personId) {
+        return;
+      }
+      const set = signals.get(personId) ?? new Set<string>();
+      set.add(signal);
+      signals.set(personId, set);
+    };
+    for (const rel of relationships) {
+      if (rel.type === "SPOUSE_OF") {
+        add(rel.fromPersonId, `spouse:${rel.toPersonId}`);
+      }
+      if (rel.type === "PARENT_OF") {
+        add(rel.toPersonId, `parent:${rel.fromPersonId}`);
+        add(rel.fromPersonId, `child:${rel.toPersonId}`);
+      }
+    }
+    for (const family of families) {
+      const parentKey = [family.parent1PersonId, family.parent2PersonId].filter(Boolean).sort().join("+");
+      for (const child of family.children) {
+        add(child.childPersonId, `parents:${parentKey}`);
+      }
+    }
+    return signals;
+  }
+
+  private jsonObject(value: unknown): Record<string, unknown> {
+    return value != null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private async moveExternalIdentities(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>
+  ) {
+    const rows = await tx.personExternalIdentity.findMany({ where: { userId, personId: duplicatePersonId } });
+    for (const row of rows) {
+      const existing = await tx.personExternalIdentity.findFirst({
+        where: {
+          userId,
+          personId: canonicalPersonId,
+          provider: row.provider,
+          providerBaseUrl: row.providerBaseUrl,
+          providerPersonId: row.providerPersonId
+        }
+      });
+      if (existing) {
+        await tx.personExternalIdentity.delete({ where: { id: row.id } });
+        increment(counts, "externalIdentityDuplicatesDeleted", 1);
+        continue;
+      }
+      await tx.personExternalIdentity.update({
+        where: { id: row.id },
+        data: { personId: canonicalPersonId }
+      });
+      increment(counts, "externalIdentitiesMoved", 1);
+    }
+  }
+
+  private async movePersonNames(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>
+  ) {
+    const canonicalPrimary = await tx.personName.findFirst({
+      where: { userId, personProfileId: canonicalPersonId, isPrimary: true }
+    });
+    const moved = await tx.personName.updateMany({
+      where: { userId, personProfileId: duplicatePersonId },
+      data: {
+        personProfileId: canonicalPersonId,
+        ...(canonicalPrimary ? { isPrimary: false } : {})
+      }
+    });
+    increment(counts, "personNames", moved.count);
+  }
+
+  private async movePersonMediaLinks(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>
+  ) {
+    const links = await tx.mediaLink.findMany({
+      where: { userId, targetType: "PERSON_PROFILE", targetId: duplicatePersonId }
+    });
+    for (const link of links) {
+      const existing = await tx.mediaLink.findFirst({
+        where: {
+          userId,
+          mediaObjectId: link.mediaObjectId,
+          targetType: "PERSON_PROFILE",
+          targetId: canonicalPersonId
+        }
+      });
+      if (existing) {
+        await tx.mediaLink.delete({ where: { id: link.id } });
+        increment(counts, "mediaLinkDuplicatesDeleted", 1);
+        continue;
+      }
+      await tx.mediaLink.update({ where: { id: link.id }, data: { targetId: canonicalPersonId } });
+      increment(counts, "mediaLinks", 1);
+    }
+  }
+
+  private async moveValidationFindings(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>
+  ) {
+    const primary = await tx.validationFinding.updateMany({
+      where: { userId, personId: duplicatePersonId },
+      data: { personId: canonicalPersonId }
+    });
+    const related = await tx.validationFinding.updateMany({
+      where: { userId, relatedPersonId: duplicatePersonId },
+      data: { relatedPersonId: canonicalPersonId }
+    });
+    increment(counts, "validationFindings", primary.count + related.count);
+  }
+
+  private async mergeFamilies(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>,
+    warnings: string[]
+  ) {
+    const families = await tx.family.findMany({
+      where: {
+        userId,
+        OR: [
+          { parent1PersonId: duplicatePersonId },
+          { parent2PersonId: duplicatePersonId },
+          { children: { some: { childPersonId: duplicatePersonId } } }
+        ]
+      },
+      include: { children: true }
+    });
+    const affectedFamilyIds = new Set(families.map((family) => family.id));
+
+    for (const family of families) {
+      const parent1PersonId =
+        family.parent1PersonId === duplicatePersonId ? canonicalPersonId : family.parent1PersonId;
+      let parent2PersonId =
+        family.parent2PersonId === duplicatePersonId ? canonicalPersonId : family.parent2PersonId;
+      if (parent1PersonId && parent1PersonId === parent2PersonId) {
+        parent2PersonId = null;
+        warnings.push(`Family ${family.id} had duplicate person in both parent slots; parent2 was cleared.`);
+      }
+      await tx.family.update({
+        where: { id: family.id },
+        data: { parent1PersonId, parent2PersonId }
+      });
+      increment(counts, "families", 1);
+
+      for (const child of family.children.filter((item) => item.childPersonId === duplicatePersonId)) {
+        const existing = await tx.familyChild.findFirst({
+          where: { familyId: family.id, childPersonId: canonicalPersonId }
+        });
+        if (existing) {
+          await tx.familyChild.delete({ where: { id: child.id } });
+          increment(counts, "familyChildDuplicatesDeleted", 1);
+        } else {
+          await tx.familyChild.update({
+            where: { id: child.id },
+            data: { childPersonId: canonicalPersonId }
+          });
+          increment(counts, "familyChildren", 1);
+        }
+      }
+    }
+
+    return affectedFamilyIds;
+  }
+
+  private async mergeRelationships(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    affectedFamilyIds: Set<string>,
+    counts: Record<string, number>
+  ) {
+    if (affectedFamilyIds.size > 0) {
+      const deleted = await tx.relationship.deleteMany({
+        where: { userId, familyId: { in: [...affectedFamilyIds] } }
+      });
+      increment(counts, "familyDerivedRelationshipsDeleted", deleted.count);
+    }
+
+    const rows = await tx.relationship.findMany({
+      where: {
+        userId,
+        familyId: null,
+        OR: [{ fromPersonId: duplicatePersonId }, { toPersonId: duplicatePersonId }]
+      }
+    });
+    for (const row of rows) {
+      const fromPersonId = row.fromPersonId === duplicatePersonId ? canonicalPersonId : row.fromPersonId;
+      const toPersonId = row.toPersonId === duplicatePersonId ? canonicalPersonId : row.toPersonId;
+      if (fromPersonId === toPersonId) {
+        await tx.relationship.delete({ where: { id: row.id } });
+        increment(counts, "relationshipSelfLoopsDeleted", 1);
+        continue;
+      }
+      const existing = await tx.relationship.findFirst({
+        where: { userId, fromPersonId, toPersonId, type: row.type, NOT: { id: row.id } }
+      });
+      if (existing) {
+        await tx.relationship.delete({ where: { id: row.id } });
+        increment(counts, "relationshipDuplicatesDeleted", 1);
+        continue;
+      }
+      await tx.relationship.update({ where: { id: row.id }, data: { fromPersonId, toPersonId } });
+      increment(counts, "relationships", 1);
+    }
+  }
+
+  private async rebuildFamilyEdges(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    affectedFamilyIds: Set<string>,
+    counts: Record<string, number>
+  ) {
+    if (affectedFamilyIds.size === 0) {
+      return;
+    }
+    const families = await tx.family.findMany({
+      where: { userId, id: { in: [...affectedFamilyIds] } },
+      include: { children: true }
+    });
+    const rows: Prisma.RelationshipCreateManyInput[] = [];
+    for (const family of families) {
+      const parents = [family.parent1PersonId, family.parent2PersonId].filter(
+        (id): id is string => typeof id === "string" && id.length > 0
+      );
+      if (parents.length === 2) {
+        const [left, right] =
+          parents[0]! < parents[1]! ? [parents[0]!, parents[1]!] : [parents[1]!, parents[0]!];
+        rows.push(
+          { userId, fromPersonId: left, toPersonId: right, type: "SPOUSE_OF" },
+          { userId, fromPersonId: right, toPersonId: left, type: "SPOUSE_OF" }
+        );
+      }
+      for (const child of family.children) {
+        if (!child.childPersonId) {
+          continue;
+        }
+        for (const parentId of parents) {
+          rows.push(
+            {
+              userId,
+              fromPersonId: parentId,
+              toPersonId: child.childPersonId,
+              type: "PARENT_OF",
+              familyId: family.id
+            },
+            {
+              userId,
+              fromPersonId: child.childPersonId,
+              toPersonId: parentId,
+              type: "CHILD_OF",
+              familyId: family.id
+            }
+          );
+        }
+      }
+    }
+    if (rows.length > 0) {
+      await tx.relationship.createMany({ data: rows, skipDuplicates: true });
+      increment(counts, "familyDerivedRelationshipsCreated", rows.length);
+    }
+  }
+
+  private async mergeCooccurrenceEdges(
+    tx: Prisma.TransactionClient,
+    userId: string,
+    duplicatePersonId: string,
+    canonicalPersonId: string,
+    counts: Record<string, number>
+  ) {
+    const rows = await tx.cooccurrenceEdge.findMany({
+      where: { userId, OR: [{ personAId: duplicatePersonId }, { personBId: duplicatePersonId }] }
+    });
+    for (const row of rows) {
+      const mappedA = row.personAId === duplicatePersonId ? canonicalPersonId : row.personAId;
+      const mappedB = row.personBId === duplicatePersonId ? canonicalPersonId : row.personBId;
+      if (mappedA === mappedB) {
+        await tx.cooccurrenceEdge.delete({ where: { id: row.id } });
+        increment(counts, "cooccurrenceSelfLoopsDeleted", 1);
+        continue;
+      }
+      const [personAId, personBId] = orderedPair(mappedA, mappedB);
+      const existing = await tx.cooccurrenceEdge.findFirst({
+        where: { userId, personAId, personBId, NOT: { id: row.id } }
+      });
+      if (existing) {
+        await tx.cooccurrenceEdge.update({
+          where: { id: existing.id },
+          data: {
+            sharedPhotos: Math.max(existing.sharedPhotos, row.sharedPhotos),
+            score: Math.max(existing.score, row.score),
+            personAPhotoCount: Math.max(existing.personAPhotoCount, row.personAPhotoCount),
+            personBPhotoCount: Math.max(existing.personBPhotoCount, row.personBPhotoCount)
+          }
+        });
+        await tx.cooccurrenceEdge.delete({ where: { id: row.id } });
+        increment(counts, "cooccurrenceDuplicatesDeleted", 1);
+        continue;
+      }
+      await tx.cooccurrenceEdge.update({ where: { id: row.id }, data: { personAId, personBId } });
+      increment(counts, "cooccurrenceEdges", 1);
+    }
+  }
+}

--- a/apps/api/src/reports/reportDataService.spec.ts
+++ b/apps/api/src/reports/reportDataService.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isLivingPerson } from "./reportDataService.js";
+
+describe("report redaction living heuristic", () => {
+  it("treats people without death events as living", () => {
+    expect(isLivingPerson({ lifeEvents: [{ eventType: "BIRTH" }] } as never)).toBe(true);
+  });
+
+  it("treats people with death events as not living", () => {
+    expect(isLivingPerson({ lifeEvents: [{ eventType: "DEATH" }] } as never)).toBe(false);
+  });
+});

--- a/apps/api/src/reports/reportDataService.ts
+++ b/apps/api/src/reports/reportDataService.ts
@@ -1,0 +1,509 @@
+import type {
+  DescendantReportRequest,
+  DescendantReportResponse,
+  FamilyGroupSheetRequest,
+  FamilyGroupSheetResponse,
+  PedigreeReportRequest,
+  PedigreeReportResponse,
+  RegisterReportRequest,
+  RegisterReportResponse,
+  ReportCitationSummary,
+  ReportLifeEventSummary,
+  ReportPersonSummary,
+  ReportWarning
+} from "@treemich/shared";
+import { lifeEventTypeLabels } from "@treemich/shared";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../db/client.js";
+import { HttpNotFoundError, HttpValidationError } from "../lifeEvents/errors.js";
+import { reportMaxDepth, reportMaxPeople } from "../config/env.js";
+import { resolveDisplayNameForPerson } from "../personNames/service.js";
+
+type PersonRow = Prisma.PersonProfileGetPayload<{
+  include: {
+    personNames: true;
+    lifeEvents: {
+      include: {
+        place: true;
+        citations: { include: { source: { include: { repository: true } } } };
+      };
+    };
+    externalIdentities: true;
+  };
+}>;
+
+type FamilyRow = Prisma.FamilyGetPayload<{
+  include: {
+    children: true;
+    lifeEvents: {
+      include: {
+        place: true;
+        citations: { include: { source: { include: { repository: true } } } };
+      };
+    };
+  };
+}>;
+
+type RelationshipRow = Prisma.RelationshipGetPayload<{}>;
+
+type ReportData = {
+  people: Map<string, PersonRow>;
+  families: FamilyRow[];
+  relationships: RelationshipRow[];
+};
+
+const fallbackName = (person: Pick<PersonRow, "id" | "displayNameOverride" | "givenName" | "surname">) =>
+  person.displayNameOverride?.trim() ||
+  [person.givenName, person.surname].filter(Boolean).join(" ").trim() ||
+  `Person ${person.id.slice(0, 8)}`;
+
+const sortPeople = (left: ReportPersonSummary, right: ReportPersonSummary) =>
+  left.displayName.localeCompare(right.displayName) || left.id.localeCompare(right.id);
+
+const sortEvents = <
+  T extends { year: number | null; month: number | null; day: number | null; label: string }
+>(
+  left: T,
+  right: T
+) =>
+  (left.year ?? 9999) - (right.year ?? 9999) ||
+  (left.month ?? 99) - (right.month ?? 99) ||
+  (left.day ?? 99) - (right.day ?? 99) ||
+  left.label.localeCompare(right.label);
+
+const dateDisplay = (event: {
+  dateQualifier: string;
+  year: number | null;
+  month: number | null;
+  day: number | null;
+  endYear: number | null;
+  endMonth: number | null;
+  endDay: number | null;
+}) => {
+  const start = [event.year, event.month, event.day].filter((part) => part != null).join("-");
+  const end = [event.endYear, event.endMonth, event.endDay].filter((part) => part != null).join("-");
+  if (!start && !end) {
+    return null;
+  }
+  const prefix = event.dateQualifier === "EXACT" ? "" : `${event.dateQualifier.toLowerCase()} `;
+  return end ? `${prefix}${start} to ${end}` : `${prefix}${start}`;
+};
+
+const placeDisplay = (place: PersonRow["lifeEvents"][number]["place"]) => {
+  if (!place) {
+    return null;
+  }
+  return [place.name, place.locality, place.adminArea, place.countryCode].filter(Boolean).join(", ");
+};
+
+const citationToSummary = (
+  citation: PersonRow["lifeEvents"][number]["citations"][number]
+): ReportCitationSummary => ({
+  id: citation.id,
+  sourceTitle: citation.source.title,
+  repositoryName: citation.source.repository?.name ?? null,
+  page: citation.page,
+  notes: citation.notes
+});
+
+const eventToSummary = (
+  event: PersonRow["lifeEvents"][number] | FamilyRow["lifeEvents"][number],
+  redacted: boolean
+): ReportLifeEventSummary => ({
+  id: event.id,
+  type: event.eventType,
+  label: event.customLabel ?? lifeEventTypeLabels[event.eventType],
+  dateQualifier: event.dateQualifier,
+  year: redacted ? null : event.year,
+  month: redacted ? null : event.month,
+  day: redacted ? null : event.day,
+  endYear: redacted ? null : event.endYear,
+  endMonth: redacted ? null : event.endMonth,
+  endDay: redacted ? null : event.endDay,
+  dateDisplay: redacted ? null : dateDisplay(event),
+  placeDisplay: redacted ? null : placeDisplay(event.place),
+  notes: redacted ? null : event.notes,
+  citations: redacted ? [] : event.citations.map(citationToSummary)
+});
+
+export const isLivingPerson = (person: Pick<PersonRow, "lifeEvents">) =>
+  !person.lifeEvents.some((event) => event.eventType === "DEATH");
+
+const personToSummary = (person: PersonRow, redactLiving: boolean): ReportPersonSummary => {
+  const living = isLivingPerson(person);
+  const redacted = redactLiving && living;
+  const primaryName =
+    person.personNames.find((name) => name.type === "BIRTH") ??
+    [...person.personNames].sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())[0] ??
+    null;
+  const primaryNameDisplay = primaryName
+    ? [primaryName.prefix, primaryName.givenName, primaryName.surname, primaryName.suffix]
+        .filter(Boolean)
+        .join(" ")
+    : null;
+  const displayName = redacted
+    ? "Living person"
+    : resolveDisplayNameForPerson({
+        immichName:
+          person.externalIdentities.find((identity) => identity.provider === "IMMICH")?.displayName ??
+          fallbackName(person),
+        displayNameOverride: person.displayNameOverride,
+        givenName: person.givenName,
+        surname: person.surname,
+        primaryName
+      });
+  return {
+    id: person.id,
+    displayName,
+    gender: redacted ? "UNKNOWN" : person.gender,
+    primaryName: redacted ? null : primaryNameDisplay,
+    alternateNames: redacted
+      ? []
+      : person.personNames
+          .filter((name) => name.id !== primaryName?.id)
+          .map((name) => [name.prefix, name.givenName, name.surname, name.suffix].filter(Boolean).join(" "))
+          .filter(Boolean)
+          .sort(),
+    isLiving: living,
+    isRedacted: redacted,
+    events: person.lifeEvents.map((event) => eventToSummary(event, redacted)).sort(sortEvents)
+  };
+};
+
+const assertDepth = (depth: number) => {
+  if (depth > reportMaxDepth()) {
+    throw new HttpValidationError(`Report depth ${depth} exceeds max depth ${reportMaxDepth()}`);
+  }
+};
+
+const assertPeopleCap = (ids: Set<string>) => {
+  if (ids.size > reportMaxPeople()) {
+    throw new HttpValidationError(
+      `Report would include ${ids.size} people; lower depth or raise TREEMICH_REPORT_MAX_PEOPLE`
+    );
+  }
+};
+
+const loadData = async (userId: string): Promise<ReportData> => {
+  const [people, families, relationships] = await Promise.all([
+    prisma.personProfile.findMany({
+      where: { userId },
+      include: {
+        personNames: { orderBy: [{ isPrimary: "desc" }, { createdAt: "asc" }] },
+        externalIdentities: true,
+        lifeEvents: {
+          include: { place: true, citations: { include: { source: { include: { repository: true } } } } },
+          orderBy: [{ year: "asc" }, { month: "asc" }, { day: "asc" }, { eventType: "asc" }]
+        }
+      },
+      orderBy: [{ surname: "asc" }, { givenName: "asc" }, { createdAt: "asc" }]
+    }),
+    prisma.family.findMany({
+      where: { userId },
+      include: {
+        children: true,
+        lifeEvents: {
+          include: { place: true, citations: { include: { source: { include: { repository: true } } } } },
+          orderBy: [{ year: "asc" }, { month: "asc" }, { day: "asc" }, { eventType: "asc" }]
+        }
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }]
+    }),
+    prisma.relationship.findMany({
+      where: { userId },
+      orderBy: [{ fromPersonId: "asc" }, { toPersonId: "asc" }, { type: "asc" }]
+    })
+  ]);
+  return { people: new Map(people.map((person) => [person.id, person])), families, relationships };
+};
+
+const requirePerson = (data: ReportData, personId: string) => {
+  const person = data.people.get(personId);
+  if (!person) {
+    throw new HttpNotFoundError("Person not found");
+  }
+  return person;
+};
+
+const requireFamily = (data: ReportData, familyId: string) => {
+  const family = data.families.find((row) => row.id === familyId);
+  if (!family) {
+    throw new HttpNotFoundError("Family not found");
+  }
+  return family;
+};
+
+const parentFamiliesForChild = (data: ReportData, childPersonId: string) => {
+  const familyRows = data.families.filter((family) =>
+    family.children.some((child) => child.childPersonId === childPersonId)
+  );
+  if (familyRows.length > 0) {
+    return familyRows;
+  }
+  const parentIds = data.relationships
+    .filter((edge) => edge.type === "PARENT_OF" && edge.toPersonId === childPersonId)
+    .map((edge) => edge.fromPersonId)
+    .sort();
+  return parentIds.length > 0
+    ? [
+        {
+          id: null,
+          parent1PersonId: parentIds[0] ?? null,
+          parent2PersonId: parentIds[1] ?? null,
+          children: [],
+          lifeEvents: [],
+          notes: null
+        } as unknown as FamilyRow
+      ]
+    : [];
+};
+
+const childFamiliesForParent = (data: ReportData, parentPersonId: string) => {
+  const familyRows = data.families.filter(
+    (family) => family.parent1PersonId === parentPersonId || family.parent2PersonId === parentPersonId
+  );
+  if (familyRows.length > 0) {
+    return familyRows;
+  }
+  const children = data.relationships
+    .filter((edge) => edge.type === "PARENT_OF" && edge.fromPersonId === parentPersonId)
+    .map((edge) => edge.toPersonId)
+    .sort();
+  return children.length > 0
+    ? [
+        {
+          id: null,
+          parent1PersonId: parentPersonId,
+          parent2PersonId: null,
+          children: children.map((childPersonId) => ({ childPersonId, pedigree: null })),
+          lifeEvents: [],
+          notes: null
+        } as unknown as FamilyRow
+      ]
+    : [];
+};
+
+const familyParents = (family: FamilyRow) =>
+  [family.parent1PersonId, family.parent2PersonId].filter((id): id is string => typeof id === "string");
+
+const familyChildren = (family: FamilyRow) =>
+  family.children
+    .filter(
+      (child): child is typeof child & { childPersonId: string } => typeof child.childPersonId === "string"
+    )
+    .sort((left, right) => left.childPersonId.localeCompare(right.childPersonId));
+
+export class ReportDataService {
+  async buildPedigreeReport(
+    userId: string,
+    parameters: PedigreeReportRequest
+  ): Promise<PedigreeReportResponse> {
+    assertDepth(parameters.depth);
+    const data = await loadData(userId);
+    const root = requirePerson(data, parameters.rootPersonId);
+    const warnings: ReportWarning[] = [];
+    const seen = new Set<string>([root.id]);
+    const generations = [{ generation: 0, people: [personToSummary(root, parameters.redactLiving)] }];
+    const edges: PedigreeReportResponse["edges"] = [];
+    let frontier = [root.id];
+
+    for (let generation = 1; generation < parameters.depth; generation += 1) {
+      const next = new Set<string>();
+      for (const childId of frontier) {
+        const families = parentFamiliesForChild(data, childId);
+        if (families.length > 1) {
+          warnings.push({
+            code: "MULTIPLE_PARENT_FAMILIES",
+            message: "Multiple parent families found",
+            personId: childId
+          });
+        }
+        for (const family of families) {
+          for (const parentId of familyParents(family)) {
+            if (seen.has(parentId)) {
+              warnings.push({
+                code: "PEDIGREE_CYCLE",
+                message: "Cycle detected while building pedigree",
+                personId: parentId
+              });
+              continue;
+            }
+            if (data.people.has(parentId)) {
+              seen.add(parentId);
+              next.add(parentId);
+              edges.push({ childPersonId: childId, parentPersonId: parentId, familyId: family.id });
+            }
+          }
+        }
+      }
+      assertPeopleCap(seen);
+      if (next.size === 0) {
+        break;
+      }
+      generations.push({
+        generation,
+        people: [...next]
+          .map((id) => personToSummary(requirePerson(data, id), parameters.redactLiving))
+          .sort(sortPeople)
+      });
+      frontier = [...next].sort();
+    }
+
+    return {
+      type: "pedigree",
+      generatedAt: new Date().toISOString(),
+      parameters,
+      warnings,
+      root: personToSummary(root, parameters.redactLiving),
+      generations,
+      edges
+    };
+  }
+
+  async buildDescendantReport(
+    userId: string,
+    parameters: DescendantReportRequest
+  ): Promise<DescendantReportResponse> {
+    assertDepth(parameters.depth);
+    const data = await loadData(userId);
+    const root = requirePerson(data, parameters.rootPersonId);
+    const warnings: ReportWarning[] = [];
+    const seen = new Set<string>([root.id]);
+    const generations: DescendantReportResponse["generations"] = [];
+    let frontier = [root.id];
+
+    for (let generation = 0; generation < parameters.depth; generation += 1) {
+      const families = frontier.flatMap((parentId) => childFamiliesForParent(data, parentId));
+      const next = new Set<string>();
+      const generationFamilies = families.map((family) => {
+        const children = familyChildren(family).flatMap((child) => {
+          const person = data.people.get(child.childPersonId);
+          if (!person) {
+            return [];
+          }
+          if (seen.has(child.childPersonId) && generation > 0) {
+            warnings.push({
+              code: "DESCENDANT_CYCLE",
+              message: "Cycle or duplicate path detected",
+              personId: child.childPersonId
+            });
+            return [];
+          }
+          seen.add(child.childPersonId);
+          next.add(child.childPersonId);
+          return [{ person: personToSummary(person, parameters.redactLiving), pedigree: child.pedigree }];
+        });
+        return {
+          familyId: family.id,
+          parents: familyParents(family)
+            .flatMap((id) => {
+              const person = data.people.get(id);
+              return person ? [personToSummary(person, parameters.redactLiving)] : [];
+            })
+            .sort(sortPeople),
+          children
+        };
+      });
+      generations.push({ generation, families: generationFamilies });
+      assertPeopleCap(seen);
+      frontier = [...next].sort();
+      if (frontier.length === 0) {
+        break;
+      }
+    }
+
+    return {
+      type: "descendants",
+      generatedAt: new Date().toISOString(),
+      parameters,
+      warnings,
+      root: personToSummary(root, parameters.redactLiving),
+      generations
+    };
+  }
+
+  async buildFamilyGroupSheet(
+    userId: string,
+    parameters: FamilyGroupSheetRequest
+  ): Promise<FamilyGroupSheetResponse> {
+    const data = await loadData(userId);
+    const family = requireFamily(data, parameters.familyId);
+    const parentSummaries = familyParents(family)
+      .flatMap((id) => {
+        const person = data.people.get(id);
+        return person ? [personToSummary(person, parameters.redactLiving)] : [];
+      })
+      .sort(sortPeople);
+    const childSummaries = familyChildren(family).flatMap((child) => {
+      const person = data.people.get(child.childPersonId);
+      return person
+        ? [{ person: personToSummary(person, parameters.redactLiving), pedigree: child.pedigree }]
+        : [];
+    });
+    const events = family.lifeEvents.map((event) => eventToSummary(event, false)).sort(sortEvents);
+    return {
+      type: "family-group",
+      generatedAt: new Date().toISOString(),
+      parameters,
+      warnings: [],
+      family: {
+        id: family.id,
+        notes: family.notes,
+        parents: parentSummaries,
+        children: childSummaries,
+        events,
+        citations: events.flatMap((event) => event.citations)
+      }
+    };
+  }
+
+  async buildRegisterReport(
+    userId: string,
+    parameters: RegisterReportRequest
+  ): Promise<RegisterReportResponse> {
+    const descendants = await this.buildDescendantReport(userId, parameters);
+    let number = 1;
+    const sections = descendants.generations.flatMap((generation) =>
+      generation.families.flatMap((family) =>
+        family.children.map((child) => {
+          const eventText = child.person.events
+            .filter((event) => event.dateDisplay || event.placeDisplay)
+            .map(
+              (event) =>
+                `${child.person.displayName} had ${event.label.toLowerCase()} ${event.dateDisplay ?? ""}${event.placeDisplay ? ` in ${event.placeDisplay}` : ""}.`
+            );
+          return {
+            number: number++,
+            generation: generation.generation + 1,
+            person: child.person,
+            familySummaries: family.parents.map((parent) => `Child of ${parent.displayName}`),
+            prose:
+              eventText.length > 0
+                ? eventText
+                : [`${child.person.displayName} appears in generation ${generation.generation + 1}.`],
+            citations: child.person.events.flatMap((event) => event.citations)
+          };
+        })
+      )
+    );
+    sections.unshift({
+      number: 1,
+      generation: 0,
+      person: descendants.root,
+      familySummaries: [],
+      prose: [`${descendants.root.displayName} is the root of this register report.`],
+      citations: descendants.root.events.flatMap((event) => event.citations)
+    });
+    sections.forEach((section, index) => {
+      section.number = index + 1;
+    });
+    return {
+      type: "register",
+      generatedAt: new Date().toISOString(),
+      parameters,
+      warnings: descendants.warnings,
+      root: descendants.root,
+      sections
+    };
+  }
+}

--- a/apps/api/src/reports/reportDataService.ts
+++ b/apps/api/src/reports/reportDataService.ts
@@ -13,7 +13,7 @@ import type {
   ReportWarning
 } from "@treemich/shared";
 import { lifeEventTypeLabels } from "@treemich/shared";
-import type { Prisma } from "@prisma/client";
+import type { Prisma, Relationship } from "@prisma/client";
 import { prisma } from "../db/client.js";
 import { HttpNotFoundError, HttpValidationError } from "../lifeEvents/errors.js";
 import { reportMaxDepth, reportMaxPeople } from "../config/env.js";
@@ -44,7 +44,7 @@ type FamilyRow = Prisma.FamilyGetPayload<{
   };
 }>;
 
-type RelationshipRow = Prisma.RelationshipGetPayload<{}>;
+type RelationshipRow = Relationship;
 
 type ReportData = {
   people: Map<string, PersonRow>;

--- a/apps/api/src/routes/evidence.ts
+++ b/apps/api/src/routes/evidence.ts
@@ -11,7 +11,8 @@ import {
   patchMediaObjectBodySchema,
   patchRepositoryBodySchema,
   patchSourceBodySchema,
-  sourceListQuerySchema
+  sourceListQuerySchema,
+  targetMediaLinkQuerySchema
 } from "@treemich/shared";
 import { z } from "zod";
 import type { FastifyInstance } from "fastify";
@@ -139,6 +140,17 @@ export const registerEvidenceRoutes = (app: FastifyInstance) => {
     const auth = getRequiredAuth(request);
     const { mediaId } = mediaIdParams.parse(request.params);
     const links = await app.services.evidenceService.listMediaLinksForObject(auth.user.id, mediaId);
+    return { links };
+  });
+
+  app.get("/evidence/media-links", async (request) => {
+    const auth = getRequiredAuth(request);
+    const query = targetMediaLinkQuerySchema.parse(request.query);
+    const links = await app.services.evidenceService.listMediaLinksForTarget(
+      auth.user.id,
+      query.targetType,
+      query.targetId
+    );
     return { links };
   });
 

--- a/apps/api/src/routes/person-duplicates.ts
+++ b/apps/api/src/routes/person-duplicates.ts
@@ -1,0 +1,49 @@
+import {
+  mergePeopleBodySchema,
+  patchPersonDuplicateCandidateBodySchema,
+  personDuplicateListQuerySchema
+} from "@treemich/shared";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { getRequiredAuth } from "../auth/request.js";
+import { EXPENSIVE_ROUTE_RATE_LIMIT } from "./rate-limit.js";
+
+const candidateParamsSchema = z.object({
+  id: z.string().min(1)
+});
+
+export const registerPersonDuplicateRoutes = (app: FastifyInstance) => {
+  app.get("/people/duplicates", async (request) => {
+    const auth = getRequiredAuth(request);
+    const query = personDuplicateListQuerySchema.parse(request.query);
+    return { candidates: await app.services.personDuplicateService!.list(auth.user.id, query) };
+  });
+
+  app.post(
+    "/people/duplicates/recompute",
+    { config: { rateLimit: EXPENSIVE_ROUTE_RATE_LIMIT } },
+    async (request) => {
+      const auth = getRequiredAuth(request);
+      return app.services.personDuplicateService!.recomputeCandidates(auth.user.id);
+    }
+  );
+
+  app.patch("/people/duplicates/:id", async (request) => {
+    const auth = getRequiredAuth(request);
+    const { id } = candidateParamsSchema.parse(request.params);
+    const body = patchPersonDuplicateCandidateBodySchema.parse(request.body);
+    return app.services.personDuplicateService!.updateStatus(auth.user.id, id, body.status);
+  });
+
+  app.post("/people/duplicates/:id/merge", async (request) => {
+    const auth = getRequiredAuth(request);
+    const { id } = candidateParamsSchema.parse(request.params);
+    const body = mergePeopleBodySchema.parse(request.body);
+    return app.services.personDuplicateService!.mergePeople(
+      auth.user.id,
+      id,
+      body.canonicalPersonId,
+      body.duplicatePersonId
+    );
+  });
+};

--- a/apps/api/src/routes/reports.spec.ts
+++ b/apps/api/src/routes/reports.spec.ts
@@ -1,0 +1,90 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { ZodError } from "zod";
+import type { AppServices } from "../services.js";
+import { registerReportRoutes } from "./reports.js";
+
+const auth = {
+  user: { id: "user-1", email: "u@example.com", name: "User" },
+  session: {
+    id: "session-1",
+    userId: "user-1",
+    tokenHash: "hash",
+    expiresAt: new Date(),
+    user: { id: "user-1", email: "u@example.com", name: "User" }
+  }
+};
+
+const buildRouteApp = async (reportService: AppServices["reportService"]) => {
+  const app = Fastify();
+  app.decorate("services", { reportService } as AppServices);
+  app.decorateRequest("auth", null);
+  app.addHook("preHandler", async (request) => {
+    request.auth = auth as never;
+  });
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ZodError) {
+      return reply.code(400).send({ statusCode: 400, error: "Validation Error" });
+    }
+    return reply.code(500).send({ statusCode: 500, error: "Internal Server Error" });
+  });
+  await app.register(registerReportRoutes);
+  await app.ready();
+  return app;
+};
+
+describe("report routes", () => {
+  it("passes default pedigree depth, redaction, and user scope to the service", async () => {
+    const buildPedigreeReport = vi.fn().mockResolvedValue({
+      type: "pedigree",
+      generatedAt: "2026-04-29T00:00:00.000Z",
+      parameters: { rootPersonId: "p1", depth: 4, redactLiving: true },
+      warnings: [],
+      root: {
+        id: "p1",
+        displayName: "Living person",
+        gender: "UNKNOWN",
+        primaryName: null,
+        alternateNames: [],
+        isLiving: true,
+        isRedacted: true,
+        events: []
+      },
+      generations: [],
+      edges: []
+    });
+    const app = await buildRouteApp({
+      buildPedigreeReport,
+      buildDescendantReport: vi.fn(),
+      buildFamilyGroupSheet: vi.fn(),
+      buildRegisterReport: vi.fn()
+    } as unknown as AppServices["reportService"]);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/reports/pedigree?rootPersonId=p1&redactLiving=true"
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(buildPedigreeReport).toHaveBeenCalledWith("user-1", {
+      rootPersonId: "p1",
+      depth: 4,
+      redactLiving: true
+    });
+    await app.close();
+  });
+
+  it("rejects missing report root ids with validation details", async () => {
+    const app = await buildRouteApp({
+      buildPedigreeReport: vi.fn(),
+      buildDescendantReport: vi.fn(),
+      buildFamilyGroupSheet: vi.fn(),
+      buildRegisterReport: vi.fn()
+    } as unknown as AppServices["reportService"]);
+
+    const res = await app.inject({ method: "GET", url: "/reports/register" });
+
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -33,7 +33,7 @@ export const registerReportRoutes = (app: FastifyInstance) => {
   }
   const reportService = app.services.reportService;
   if (!reportService) {
-    throw new Error("Report service is not registered");
+    return;
   }
 
   app.get(

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,118 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+import { z } from "zod";
+import { getRequiredAuth } from "../auth/request.js";
+import { isReportsEnabled } from "../config/env.js";
+import { HttpNotFoundError, HttpValidationError } from "../lifeEvents/errors.js";
+import { EXPENSIVE_ROUTE_RATE_LIMIT } from "./rate-limit.js";
+
+const booleanQuerySchema = z
+  .enum(["1", "0", "true", "false", "yes", "no", "on", "off"])
+  .optional()
+  .transform((value) => (value == null ? false : ["1", "true", "yes", "on"].includes(value)));
+
+const depthQuerySchema = z.object({
+  rootPersonId: z.string().min(1),
+  depth: z.coerce.number().int().min(1).optional(),
+  redactLiving: booleanQuerySchema
+});
+
+const familyGroupQuerySchema = z.object({
+  familyId: z.string().min(1),
+  redactLiving: booleanQuerySchema
+});
+
+const sendHttpError = (reply: FastifyReply, error: HttpNotFoundError | HttpValidationError) =>
+  reply.code(error.statusCode).send({
+    statusCode: error.statusCode,
+    error: error.message
+  });
+
+export const registerReportRoutes = (app: FastifyInstance) => {
+  if (!isReportsEnabled()) {
+    return;
+  }
+  const reportService = app.services.reportService;
+  if (!reportService) {
+    throw new Error("Report service is not registered");
+  }
+
+  app.get(
+    "/reports/pedigree",
+    { config: { rateLimit: EXPENSIVE_ROUTE_RATE_LIMIT } },
+    async (request, reply) => {
+      const auth = getRequiredAuth(request);
+      const query = depthQuerySchema.parse(request.query);
+      try {
+        return await reportService.buildPedigreeReport(auth.user.id, {
+          rootPersonId: query.rootPersonId,
+          depth: query.depth ?? 4,
+          redactLiving: query.redactLiving
+        });
+      } catch (error) {
+        if (error instanceof HttpNotFoundError || error instanceof HttpValidationError) {
+          return sendHttpError(reply, error);
+        }
+        throw error;
+      }
+    }
+  );
+
+  app.get(
+    "/reports/descendants",
+    { config: { rateLimit: EXPENSIVE_ROUTE_RATE_LIMIT } },
+    async (request, reply) => {
+      const auth = getRequiredAuth(request);
+      const query = depthQuerySchema.parse(request.query);
+      try {
+        return await reportService.buildDescendantReport(auth.user.id, {
+          rootPersonId: query.rootPersonId,
+          depth: query.depth ?? 3,
+          redactLiving: query.redactLiving
+        });
+      } catch (error) {
+        if (error instanceof HttpNotFoundError || error instanceof HttpValidationError) {
+          return sendHttpError(reply, error);
+        }
+        throw error;
+      }
+    }
+  );
+
+  app.get(
+    "/reports/family-group",
+    { config: { rateLimit: EXPENSIVE_ROUTE_RATE_LIMIT } },
+    async (request, reply) => {
+      const auth = getRequiredAuth(request);
+      const query = familyGroupQuerySchema.parse(request.query);
+      try {
+        return await reportService.buildFamilyGroupSheet(auth.user.id, query);
+      } catch (error) {
+        if (error instanceof HttpNotFoundError || error instanceof HttpValidationError) {
+          return sendHttpError(reply, error);
+        }
+        throw error;
+      }
+    }
+  );
+
+  app.get(
+    "/reports/register",
+    { config: { rateLimit: EXPENSIVE_ROUTE_RATE_LIMIT } },
+    async (request, reply) => {
+      const auth = getRequiredAuth(request);
+      const query = depthQuerySchema.parse(request.query);
+      try {
+        return await reportService.buildRegisterReport(auth.user.id, {
+          rootPersonId: query.rootPersonId,
+          depth: query.depth ?? 3,
+          redactLiving: query.redactLiving
+        });
+      } catch (error) {
+        if (error instanceof HttpNotFoundError || error instanceof HttpValidationError) {
+          return sendHttpError(reply, error);
+        }
+        throw error;
+      }
+    }
+  );
+};

--- a/apps/api/src/routes/tree-validation.get.ts
+++ b/apps/api/src/routes/tree-validation.get.ts
@@ -19,7 +19,13 @@ const querySchema = z.object({
 export const registerTreeValidationGetRoute = (app: FastifyInstance) => {
   app.get("/tree/validation", async (request) => {
     const auth = getRequiredAuth(request);
-    querySchema.parse(request.query);
+    const query = querySchema.parse(request.query);
+    if (query.persist === "true") {
+      throw {
+        statusCode: 400,
+        message: "GET /tree/validation is read-only; use POST /validation/recompute to persist findings"
+      };
+    }
     if (!isTreeValidationEngineEnabled()) {
       return { findings: [], engineDisabled: true as const, persist: false as const };
     }

--- a/apps/api/src/routes/validation-findings.ts
+++ b/apps/api/src/routes/validation-findings.ts
@@ -1,0 +1,52 @@
+import { patchValidationFindingBodySchema, validationFindingListQuerySchema } from "@treemich/shared";
+import { z } from "zod";
+import type { FastifyInstance } from "fastify";
+import { getRequiredAuth } from "../auth/request.js";
+import { isTreeValidationEngineEnabled } from "../config/env.js";
+import { computeTreeValidationForUser } from "../validation/treeValidationService.js";
+
+const findingParamsSchema = z.object({
+  id: z.string().min(1)
+});
+
+export const registerValidationFindingRoutes = (app: FastifyInstance) => {
+  app.get("/validation/findings", async (request) => {
+    const auth = getRequiredAuth(request);
+    const query = validationFindingListQuerySchema.parse(request.query);
+    const findings = await app.services.validationFindingService!.list(auth.user.id, query);
+    return { findings };
+  });
+
+  app.post("/validation/recompute", async (request, reply) => {
+    const auth = getRequiredAuth(request);
+    if (!isTreeValidationEngineEnabled()) {
+      return reply.code(409).send({
+        statusCode: 409,
+        error: "Validation engine disabled",
+        engineDisabled: true
+      });
+    }
+    const computed = await computeTreeValidationForUser(auth.user.id);
+    const result = await app.services.validationFindingService!.persistTreeValidationFindings(
+      auth.user.id,
+      computed
+    );
+    return {
+      findings: result.findings,
+      summary: result.summary,
+      engineDisabled: false
+    };
+  });
+
+  app.patch("/validation/findings/:id", async (request) => {
+    const auth = getRequiredAuth(request);
+    const params = findingParamsSchema.parse(request.params);
+    const body = patchValidationFindingBodySchema.parse(request.body);
+    const finding = await app.services.validationFindingService!.updateStatus(
+      auth.user.id,
+      params.id,
+      body.status
+    );
+    return finding;
+  });
+};

--- a/apps/api/src/services.ts
+++ b/apps/api/src/services.ts
@@ -20,6 +20,7 @@ import { PersonNameService } from "./personNames/service.js";
 import { EvidenceService } from "./evidence/service.js";
 import { FamilyService } from "./families/service.js";
 import { PersonService } from "./people/service.js";
+import { ReportDataService } from "./reports/reportDataService.js";
 import { ResearchTaskService } from "./researchTasks/service.js";
 import { RelationshipService } from "./relationships/service.js";
 import { ValidationFindingService } from "./validation/validationFindingService.js";
@@ -38,6 +39,7 @@ export type AppServices = {
   researchTaskService: ResearchTaskService;
   evidenceService: EvidenceService;
   validationFindingService?: ValidationFindingService;
+  reportService?: ReportDataService;
 };
 
 /** Constructs default service instances (shared `LifeEventService` wired into `RelationshipService`). */
@@ -57,7 +59,8 @@ export const buildServices = (): AppServices => {
     personNameService: new PersonNameService(),
     researchTaskService: new ResearchTaskService(personService),
     evidenceService: new EvidenceService(),
-    validationFindingService: new ValidationFindingService()
+    validationFindingService: new ValidationFindingService(),
+    reportService: new ReportDataService()
   };
 };
 

--- a/apps/api/src/services.ts
+++ b/apps/api/src/services.ts
@@ -15,6 +15,7 @@ import { TreemichAuthError } from "./auth/service.js";
 import { CooccurrenceService } from "./cooccurrence/service.js";
 import { ImmichClientFactory } from "./integrations/immich/factory.js";
 import { LifeEventService } from "./lifeEvents/service.js";
+import { PersonDuplicateService } from "./personDuplicates/service.js";
 import { PersonNameService } from "./personNames/service.js";
 import { EvidenceService } from "./evidence/service.js";
 import { FamilyService } from "./families/service.js";
@@ -30,6 +31,7 @@ export type AppServices = {
   immichClientFactory: ImmichClientFactory;
   relationshipService: RelationshipService;
   personService: PersonService;
+  personDuplicateService?: PersonDuplicateService;
   familyService: FamilyService;
   lifeEventService: LifeEventService;
   personNameService: PersonNameService;
@@ -48,6 +50,7 @@ export const buildServices = (): AppServices => {
     cooccurrenceService: new CooccurrenceService(),
     immichClientFactory: new ImmichClientFactory(),
     personService,
+    personDuplicateService: new PersonDuplicateService(),
     relationshipService,
     familyService: new FamilyService(relationshipService, personService),
     lifeEventService,

--- a/apps/api/src/services.ts
+++ b/apps/api/src/services.ts
@@ -21,6 +21,7 @@ import { FamilyService } from "./families/service.js";
 import { PersonService } from "./people/service.js";
 import { ResearchTaskService } from "./researchTasks/service.js";
 import { RelationshipService } from "./relationships/service.js";
+import { ValidationFindingService } from "./validation/validationFindingService.js";
 
 /** Service container attached to each Fastify instance (`app.services`). */
 export type AppServices = {
@@ -34,6 +35,7 @@ export type AppServices = {
   personNameService: PersonNameService;
   researchTaskService: ResearchTaskService;
   evidenceService: EvidenceService;
+  validationFindingService?: ValidationFindingService;
 };
 
 /** Constructs default service instances (shared `LifeEventService` wired into `RelationshipService`). */
@@ -51,7 +53,8 @@ export const buildServices = (): AppServices => {
     lifeEventService,
     personNameService: new PersonNameService(),
     researchTaskService: new ResearchTaskService(personService),
-    evidenceService: new EvidenceService()
+    evidenceService: new EvidenceService(),
+    validationFindingService: new ValidationFindingService()
   };
 };
 

--- a/apps/api/src/validation/validationFindingService.spec.ts
+++ b/apps/api/src/validation/validationFindingService.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { fingerprintFinding } from "./validationFindingService.js";
+
+describe("fingerprintFinding", () => {
+  it("uses stable issue identity and excludes message text", () => {
+    const first = fingerprintFinding({
+      code: "parent_birth_after_child",
+      severity: "error",
+      message: "Old wording",
+      personId: "parent",
+      relatedPersonId: "child",
+      relationshipId: "rel"
+    });
+    const second = fingerprintFinding({
+      code: "parent_birth_after_child",
+      severity: "error",
+      message: "Improved wording",
+      personId: "parent",
+      relatedPersonId: "child",
+      relationshipId: "rel"
+    });
+
+    expect(first).toBe(second);
+    expect(first).toBe("parent_birth_after_child|parent|rel|child|");
+  });
+
+  it("includes family id when present", () => {
+    expect(
+      fingerprintFinding({
+        code: "family_issue",
+        severity: "warning",
+        message: "Family issue",
+        familyId: "fam1"
+      })
+    ).toBe("family_issue||||fam1");
+  });
+});

--- a/apps/api/src/validation/validationFindingService.ts
+++ b/apps/api/src/validation/validationFindingService.ts
@@ -1,0 +1,266 @@
+import type {
+  ValidationFindingListQuery,
+  ValidationFindingRecord,
+  ValidationFindingStatus,
+  ValidationRecomputeSummary
+} from "@treemich/shared";
+import { formatPersonNameDisplay } from "@treemich/shared";
+import { prisma } from "../db/client.js";
+import type { LifeEventValidationFinding } from "../lifeEvents/personLifeEventValidation.js";
+
+type PersistableFinding = LifeEventValidationFinding & { familyId?: string };
+
+const statusToPrisma = (status: ValidationFindingStatus) => status;
+const severityToPrisma = (severity: PersistableFinding["severity"]) =>
+  severity === "error" ? "ERROR" : "WARNING";
+const severityFromPrisma = (severity: "ERROR" | "WARNING") => (severity === "ERROR" ? "error" : "warning");
+
+export const fingerprintFinding = (finding: PersistableFinding): string =>
+  [
+    finding.code,
+    finding.personId ?? "",
+    finding.relationshipId ?? "",
+    finding.relatedPersonId ?? "",
+    finding.familyId ?? ""
+  ].join("|");
+
+const personLabel = (
+  person?: { displayNameOverride: string | null; givenName: string | null; surname: string | null } | null
+) => (person ? formatPersonNameDisplay(person) : null);
+
+const notFound = (message: string) => {
+  const err = new Error(message);
+  (err as Error & { statusCode: number }).statusCode = 404;
+  return err;
+};
+
+type ValidationFindingRow = Awaited<ReturnType<typeof prisma.validationFinding.findMany>>[number];
+
+type EnrichedValidationFindingRow = ValidationFindingRow & {
+  person?: {
+    id: string;
+    displayNameOverride: string | null;
+    givenName: string | null;
+    surname: string | null;
+  } | null;
+  relatedPerson?: {
+    id: string;
+    displayNameOverride: string | null;
+    givenName: string | null;
+    surname: string | null;
+  } | null;
+  relationship?: {
+    id: string;
+    type: string;
+    fromPersonId: string;
+    toPersonId: string;
+    fromPerson: { displayNameOverride: string | null; givenName: string | null; surname: string | null };
+    toPerson: { displayNameOverride: string | null; givenName: string | null; surname: string | null };
+  } | null;
+  family?: {
+    id: string;
+    parent1: { displayNameOverride: string | null; givenName: string | null; surname: string | null } | null;
+    parent2: { displayNameOverride: string | null; givenName: string | null; surname: string | null } | null;
+  } | null;
+};
+
+const familyLabel = (family: EnrichedValidationFindingRow["family"]) => {
+  if (!family) {
+    return null;
+  }
+  const parent1 = personLabel(family.parent1) ?? "Unknown parent";
+  const parent2 = personLabel(family.parent2) ?? "Unknown parent";
+  return `${parent1} + ${parent2}`;
+};
+
+const relationshipLabel = (relationship: EnrichedValidationFindingRow["relationship"]) => {
+  if (!relationship) {
+    return null;
+  }
+  const from = personLabel(relationship.fromPerson) ?? relationship.fromPersonId;
+  const to = personLabel(relationship.toPerson) ?? relationship.toPersonId;
+  return `${from} ${relationship.type} ${to}`;
+};
+
+const toRecord = (row: EnrichedValidationFindingRow): ValidationFindingRecord => ({
+  id: row.id,
+  code: row.code,
+  severity: severityFromPrisma(row.severity),
+  message: row.message,
+  personId: row.personId,
+  relationshipId: row.relationshipId,
+  relatedPersonId: row.relatedPersonId,
+  familyId: row.familyId,
+  status: row.status,
+  fingerprint: row.fingerprint,
+  firstSeenAt: row.firstSeenAt.toISOString(),
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  resolvedAt: row.resolvedAt?.toISOString() ?? null,
+  dismissedAt: row.dismissedAt?.toISOString() ?? null,
+  inProgressAt: row.inProgressAt?.toISOString() ?? null,
+  metadata:
+    row.metadata && typeof row.metadata === "object" && !Array.isArray(row.metadata)
+      ? (row.metadata as Record<string, unknown>)
+      : {},
+  display: {
+    person: row.person ? { id: row.person.id, label: personLabel(row.person) ?? row.person.id } : null,
+    relatedPerson: row.relatedPerson
+      ? { id: row.relatedPerson.id, label: personLabel(row.relatedPerson) ?? row.relatedPerson.id }
+      : null,
+    relationship: row.relationship
+      ? {
+          id: row.relationship.id,
+          label: relationshipLabel(row.relationship) ?? row.relationship.id,
+          fromPersonId: row.relationship.fromPersonId,
+          toPersonId: row.relationship.toPersonId
+        }
+      : null,
+    family: row.family ? { id: row.family.id, label: familyLabel(row.family) ?? row.family.id } : null
+  }
+});
+
+export class ValidationFindingService {
+  async persistTreeValidationFindings(
+    userId: string,
+    findings: PersistableFinding[]
+  ): Promise<{ findings: ValidationFindingRecord[]; summary: ValidationRecomputeSummary }> {
+    const now = new Date();
+    const fingerprints = new Set(findings.map(fingerprintFinding));
+    const summary: ValidationRecomputeSummary = {
+      current: findings.length,
+      created: 0,
+      reopened: 0,
+      resolved: 0,
+      inProgressStillPresent: 0,
+      dismissedStillPresent: 0
+    };
+
+    await prisma.$transaction(async (tx) => {
+      for (const finding of findings) {
+        const fingerprint = fingerprintFinding(finding);
+        const existing = await tx.validationFinding.findUnique({
+          where: { userId_fingerprint: { userId, fingerprint } }
+        });
+        if (!existing) {
+          summary.created += 1;
+          await tx.validationFinding.create({
+            data: {
+              userId,
+              code: finding.code,
+              severity: severityToPrisma(finding.severity),
+              message: finding.message,
+              personId: finding.personId ?? null,
+              relationshipId: finding.relationshipId ?? null,
+              relatedPersonId: finding.relatedPersonId ?? null,
+              familyId: finding.familyId ?? null,
+              fingerprint,
+              lastSeenAt: now
+            }
+          });
+          continue;
+        }
+
+        const nextStatus = existing.status === "RESOLVED" ? "OPEN" : existing.status;
+        if (existing.status === "RESOLVED") {
+          summary.reopened += 1;
+        } else if (existing.status === "DISMISSED") {
+          summary.dismissedStillPresent += 1;
+        } else if (existing.status === "IN_PROGRESS") {
+          summary.inProgressStillPresent += 1;
+        }
+
+        await tx.validationFinding.update({
+          where: { id: existing.id },
+          data: {
+            code: finding.code,
+            severity: severityToPrisma(finding.severity),
+            message: finding.message,
+            personId: finding.personId ?? null,
+            relationshipId: finding.relationshipId ?? null,
+            relatedPersonId: finding.relatedPersonId ?? null,
+            familyId: finding.familyId ?? null,
+            status: nextStatus,
+            lastSeenAt: now,
+            ...(nextStatus === "OPEN" ? { resolvedAt: null } : {})
+          }
+        });
+      }
+
+      const stale = await tx.validationFinding.updateMany({
+        where: {
+          userId,
+          status: { in: ["OPEN", "IN_PROGRESS"] },
+          fingerprint: { notIn: [...fingerprints] }
+        },
+        data: {
+          status: "RESOLVED",
+          resolvedAt: now
+        }
+      });
+      summary.resolved = stale.count;
+    });
+
+    return {
+      findings: await this.list(userId, { status: ["OPEN", "IN_PROGRESS"] }),
+      summary
+    };
+  }
+
+  async list(userId: string, query: ValidationFindingListQuery = {}): Promise<ValidationFindingRecord[]> {
+    const status = Array.isArray(query.status) ? query.status : query.status ? [query.status] : undefined;
+    const rows = await prisma.validationFinding.findMany({
+      where: {
+        userId,
+        ...(status?.length ? { status: { in: status.map(statusToPrisma) } } : {}),
+        ...(query.severity ? { severity: severityToPrisma(query.severity) } : {}),
+        ...(query.code ? { code: query.code } : {}),
+        ...(query.personId ? { personId: query.personId } : {}),
+        ...(query.familyId ? { familyId: query.familyId } : {})
+      },
+      include: {
+        person: true,
+        relatedPerson: true,
+        relationship: { include: { fromPerson: true, toPerson: true } },
+        family: { include: { parent1: true, parent2: true } }
+      },
+      orderBy: [{ status: "asc" }, { lastSeenAt: "desc" }, { id: "asc" }],
+      take: query.limit ?? 100,
+      skip: query.offset ?? 0
+    });
+    return rows.map(toRecord);
+  }
+
+  async updateStatus(
+    userId: string,
+    findingId: string,
+    status: "OPEN" | "IN_PROGRESS" | "DISMISSED"
+  ): Promise<ValidationFindingRecord> {
+    const existing = await prisma.validationFinding.findFirst({ where: { id: findingId, userId } });
+    if (!existing) {
+      throw notFound("Validation finding not found");
+    }
+    const now = new Date();
+    await prisma.validationFinding.update({
+      where: { id: findingId },
+      data: {
+        status,
+        ...(status === "OPEN" ? { dismissedAt: null, inProgressAt: null, resolvedAt: null } : {}),
+        ...(status === "IN_PROGRESS" ? { inProgressAt: now, dismissedAt: null, resolvedAt: null } : {}),
+        ...(status === "DISMISSED" ? { dismissedAt: now, inProgressAt: null } : {})
+      }
+    });
+    const row = await prisma.validationFinding.findFirst({
+      where: { id: findingId, userId },
+      include: {
+        person: true,
+        relatedPerson: true,
+        relationship: { include: { fromPerson: true, toPerson: true } },
+        family: { include: { parent1: true, parent2: true } }
+      }
+    });
+    if (!row) {
+      throw notFound("Validation finding not found");
+    }
+    return toRecord(row);
+  }
+}

--- a/apps/api/test/relationships.e2e.spec.ts
+++ b/apps/api/test/relationships.e2e.spec.ts
@@ -22,6 +22,10 @@ const getCooccurrenceEdgeBetweenMock = vi.fn();
 const getPersistedPhotoCooccurrenceMock = vi.fn();
 const syncCooccurrenceScheduleFromPreferencesMock = vi.fn();
 const listPeopleMock = vi.fn();
+const listDuplicateCandidatesMock = vi.fn();
+const recomputeDuplicateCandidatesMock = vi.fn();
+const updateDuplicateCandidateMock = vi.fn();
+const mergeDuplicateCandidateMock = vi.fn();
 const getPersonThumbnailMock = vi.fn();
 const listAssetsWithPeopleMock = vi.fn();
 const loginWithImmichMock = vi.fn();
@@ -317,6 +321,17 @@ describe("Treemich API routes", () => {
       }
     });
     listPersonServiceMock.mockResolvedValue([]);
+    listDuplicateCandidatesMock.mockResolvedValue([]);
+    recomputeDuplicateCandidatesMock.mockResolvedValue({
+      candidates: [],
+      summary: { created: 0, updated: 0, preservedDismissed: 0, pending: 0 }
+    });
+    updateDuplicateCandidateMock.mockResolvedValue({ id: "dup-1", status: "DISMISSED" });
+    mergeDuplicateCandidateMock.mockResolvedValue({
+      auditId: "audit-1",
+      canonicalPersonId: "p1",
+      duplicatePersonId: "p2"
+    });
     resolvePersonIdMock.mockImplementation((_userId: string, id: string) => Promise.resolve(id));
     listExternalIdentitiesMock.mockResolvedValue([]);
     deletePersonServiceMock.mockResolvedValue(undefined);
@@ -369,6 +384,12 @@ describe("Treemich API routes", () => {
         deleteExternalIdentity: deleteExternalIdentityMock,
         delete: deletePersonServiceMock
       } as unknown as AppServices["personService"],
+      personDuplicateService: {
+        list: listDuplicateCandidatesMock,
+        recomputeCandidates: recomputeDuplicateCandidatesMock,
+        updateStatus: updateDuplicateCandidateMock,
+        mergePeople: mergeDuplicateCandidateMock
+      } as unknown as AppServices["personDuplicateService"],
       lifeEventService: lifeEventServiceMock as unknown as AppServices["lifeEventService"],
       personNameService: personNameServiceMock as unknown as AppServices["personNameService"],
       researchTaskService: researchTaskServiceMock as unknown as AppServices["researchTaskService"],
@@ -526,6 +547,74 @@ describe("Treemich API routes", () => {
     expect(json.people).toHaveLength(1);
     expect(json.people[0].id).toBe("p1");
     expect(json.people[0].hasRelationship).toBe(true);
+  });
+
+  it("lists duplicate candidates", async () => {
+    listDuplicateCandidatesMock.mockResolvedValueOnce([{ id: "dup-1", status: "PENDING" }]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/people/duplicates?status=PENDING&limit=25"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ candidates: [{ id: "dup-1", status: "PENDING" }] });
+    expect(listDuplicateCandidatesMock).toHaveBeenCalledWith("user-1", { status: "PENDING", limit: 25 });
+  });
+
+  it("recomputes duplicate candidates", async () => {
+    recomputeDuplicateCandidatesMock.mockResolvedValueOnce({
+      candidates: [],
+      summary: { created: 1, updated: 0, preservedDismissed: 0, pending: 1 }
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/people/duplicates/recompute"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      candidates: [],
+      summary: { created: 1, updated: 0, preservedDismissed: 0, pending: 1 }
+    });
+    expect(recomputeDuplicateCandidatesMock).toHaveBeenCalledWith("user-1");
+  });
+
+  it("dismisses duplicate candidates", async () => {
+    updateDuplicateCandidateMock.mockResolvedValueOnce({ id: "dup-1", status: "DISMISSED" });
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/people/duplicates/dup-1",
+      payload: { status: "DISMISSED" }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ id: "dup-1", status: "DISMISSED" });
+    expect(updateDuplicateCandidateMock).toHaveBeenCalledWith("user-1", "dup-1", "DISMISSED");
+  });
+
+  it("merges duplicate candidates after explicit confirmation", async () => {
+    mergeDuplicateCandidateMock.mockResolvedValueOnce({
+      auditId: "audit-1",
+      canonicalPersonId: "p1",
+      duplicatePersonId: "p2"
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/people/duplicates/dup-1/merge",
+      payload: { canonicalPersonId: "p1", duplicatePersonId: "p2", confirm: true }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      auditId: "audit-1",
+      canonicalPersonId: "p1",
+      duplicatePersonId: "p2"
+    });
+    expect(mergeDuplicateCandidateMock).toHaveBeenCalledWith("user-1", "dup-1", "p1", "p2");
   });
 
   it("updates gender profile", async () => {

--- a/apps/web/src/components/DuplicateReviewWorkspace.spec.tsx
+++ b/apps/web/src/components/DuplicateReviewWorkspace.spec.tsx
@@ -1,0 +1,124 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DuplicateReviewWorkspace } from "./DuplicateReviewWorkspace";
+import type { PersonDuplicateCandidateRecord } from "../lib/api";
+
+const reactTestEnvironment = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+reactTestEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const candidate = (
+  overrides: Partial<PersonDuplicateCandidateRecord> = {}
+): PersonDuplicateCandidateRecord => ({
+  id: "dup-1",
+  personAId: "p1",
+  personBId: "p2",
+  score: 85,
+  reasons: [{ code: "name", label: "Same full name", weight: 45 }],
+  status: "PENDING",
+  dismissedAt: null,
+  mergedAt: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  personA: {
+    id: "p1",
+    label: "Alex Smith",
+    givenName: "Alex",
+    surname: "Smith",
+    birthDate: "1900",
+    deathDate: null,
+    externalIdentityCount: 1
+  },
+  personB: {
+    id: "p2",
+    label: "Alexander Smith",
+    givenName: "Alexander",
+    surname: "Smith",
+    birthDate: "1900",
+    deathDate: null,
+    externalIdentityCount: 0
+  },
+  ...overrides
+});
+
+describe("DuplicateReviewWorkspace", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders pending candidates and opens either person", async () => {
+    const onOpenPerson = vi.fn();
+
+    await act(async () => {
+      root.render(
+        createElement(DuplicateReviewWorkspace, {
+          candidates: [candidate()],
+          loading: false,
+          onRefresh: vi.fn(),
+          onRecompute: vi.fn(),
+          onDismiss: vi.fn(),
+          onMerge: vi.fn(),
+          onOpenPerson
+        })
+      );
+    });
+
+    expect(host.textContent).toContain("Alex Smith / Alexander Smith");
+    expect(host.textContent).toContain("Score 85");
+
+    const buttons = [...host.querySelectorAll("button")];
+    buttons.find((button) => button.textContent === "Open second")?.click();
+    expect(onOpenPerson).toHaveBeenCalledWith("p2");
+  });
+
+  it("dismisses and merges selected canonical person", async () => {
+    const onDismiss = vi.fn().mockResolvedValue(undefined);
+    const onMerge = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "confirm", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true)
+    });
+
+    await act(async () => {
+      root.render(
+        createElement(DuplicateReviewWorkspace, {
+          candidates: [candidate()],
+          loading: false,
+          onRefresh: vi.fn(),
+          onRecompute: vi.fn(),
+          onDismiss,
+          onMerge,
+          onOpenPerson: vi.fn()
+        })
+      );
+    });
+
+    const select = host.querySelector("select") as HTMLSelectElement;
+    await act(async () => {
+      select.value = "p2";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const buttons = [...host.querySelectorAll("button")];
+    await act(async () => {
+      buttons.find((button) => button.textContent === "Dismiss")?.click();
+    });
+    expect(onDismiss).toHaveBeenCalledWith("dup-1");
+
+    await act(async () => {
+      buttons.find((button) => button.textContent === "Merge")?.click();
+    });
+    expect(onMerge).toHaveBeenCalledWith("dup-1", "p2", "p1");
+  });
+});

--- a/apps/web/src/components/DuplicateReviewWorkspace.tsx
+++ b/apps/web/src/components/DuplicateReviewWorkspace.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react";
+import type { PersonDuplicateCandidateRecord } from "../lib/api";
+
+type Props = {
+  candidates: PersonDuplicateCandidateRecord[];
+  loading: boolean;
+  onRefresh: () => Promise<void>;
+  onRecompute: () => Promise<void>;
+  onDismiss: (candidateId: string) => Promise<void>;
+  onMerge: (candidateId: string, canonicalPersonId: string, duplicatePersonId: string) => Promise<void>;
+  onOpenPerson: (personId: string) => void;
+};
+
+const formatPersonMeta = (person: PersonDuplicateCandidateRecord["personA"]) =>
+  [
+    person.birthDate ? `b. ${person.birthDate}` : null,
+    person.deathDate ? `d. ${person.deathDate}` : null,
+    person.externalIdentityCount > 0 ? `${person.externalIdentityCount} external id(s)` : null
+  ]
+    .filter(Boolean)
+    .join(" | ");
+
+export const DuplicateReviewWorkspace = ({
+  candidates,
+  loading,
+  onRefresh,
+  onRecompute,
+  onDismiss,
+  onMerge,
+  onOpenPerson
+}: Props) => {
+  const [busyCandidateId, setBusyCandidateId] = useState<string | null>(null);
+  const [busyGlobal, setBusyGlobal] = useState(false);
+  const [canonicalByCandidateId, setCanonicalByCandidateId] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const pendingCandidates = useMemo(
+    () => candidates.filter((candidate) => candidate.status === "PENDING"),
+    [candidates]
+  );
+
+  const wrapGlobal = async (fn: () => Promise<void>) => {
+    setBusyGlobal(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Duplicate action failed");
+    } finally {
+      setBusyGlobal(false);
+    }
+  };
+
+  const wrapCandidate = async (candidateId: string, fn: () => Promise<void>) => {
+    setBusyCandidateId(candidateId);
+    setError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Duplicate action failed");
+    } finally {
+      setBusyCandidateId(null);
+    }
+  };
+
+  const confirmMerge = async (candidate: PersonDuplicateCandidateRecord) => {
+    const canonicalPersonId = canonicalByCandidateId[candidate.id] ?? candidate.personAId;
+    const canonical = canonicalPersonId === candidate.personAId ? candidate.personA : candidate.personB;
+    const duplicate = canonicalPersonId === candidate.personAId ? candidate.personB : candidate.personA;
+    const message = `Merge ${duplicate.label} into ${canonical.label}? The duplicate profile will be removed after its links move.`;
+    if (!window.confirm(message)) {
+      return;
+    }
+    await onMerge(candidate.id, canonical.id, duplicate.id);
+  };
+
+  return (
+    <section className="workspace-main-stack workspace-main-stack--secondary">
+      <section className="card stack workspace-intro-card">
+        <div className="stack">
+          <h2>Duplicate review</h2>
+          <p className="hint">Review possible duplicate people before any merge changes data.</p>
+        </div>
+        {error ? <p className="hint hint--danger">{error}</p> : null}
+        <div className="workspace-action-row">
+          <span className="status-pill">Pending: {pendingCandidates.length}</span>
+          <button
+            type="button"
+            className="secondary-button workspace-action-button"
+            disabled={busyGlobal}
+            onClick={() => void wrapGlobal(onRecompute)}
+          >
+            Recompute candidates
+          </button>
+          <button
+            type="button"
+            className="secondary-button workspace-action-button"
+            disabled={busyGlobal}
+            onClick={() => void wrapGlobal(onRefresh)}
+          >
+            Refresh
+          </button>
+        </div>
+      </section>
+
+      <section className="card stack workspace-intro-card">
+        <h3>Candidate queue</h3>
+        {loading ? <p className="hint">Loading duplicate candidates...</p> : null}
+        {!loading && pendingCandidates.length === 0 ? (
+          <p className="hint">No pending duplicate candidates. Recompute to scan current people.</p>
+        ) : null}
+        <ul className="research-task-list">
+          {pendingCandidates.map((candidate) => {
+            const canonicalPersonId = canonicalByCandidateId[candidate.id] ?? candidate.personAId;
+            const busy = busyCandidateId === candidate.id;
+            return (
+              <li key={candidate.id} className="research-task-item">
+                <span className="status-pill">Score {candidate.score}</span>
+                <div className="stack">
+                  <strong>
+                    {candidate.personA.label} / {candidate.personB.label}
+                  </strong>
+                  <span className="hint">
+                    {formatPersonMeta(candidate.personA) || "No vitals for first person"}
+                  </span>
+                  <span className="hint">
+                    {formatPersonMeta(candidate.personB) || "No vitals for second person"}
+                  </span>
+                  <span className="hint">
+                    {candidate.reasons.map((reason) => reason.label).join(", ") || "No reason details"}
+                  </span>
+                </div>
+                <label className="settings-toggle">
+                  <select
+                    value={canonicalPersonId}
+                    disabled={busy}
+                    aria-label={`Canonical person for ${candidate.personA.label} and ${candidate.personB.label}`}
+                    onChange={(event) =>
+                      setCanonicalByCandidateId((current) => ({
+                        ...current,
+                        [candidate.id]: event.target.value
+                      }))
+                    }
+                  >
+                    <option value={candidate.personAId}>Keep {candidate.personA.label}</option>
+                    <option value={candidate.personBId}>Keep {candidate.personB.label}</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  className="text-link-button"
+                  onClick={() => onOpenPerson(candidate.personAId)}
+                >
+                  Open first
+                </button>
+                <button
+                  type="button"
+                  className="text-link-button"
+                  onClick={() => onOpenPerson(candidate.personBId)}
+                >
+                  Open second
+                </button>
+                <button
+                  type="button"
+                  className="text-link-button"
+                  disabled={busy}
+                  onClick={() => void wrapCandidate(candidate.id, () => onDismiss(candidate.id))}
+                >
+                  Dismiss
+                </button>
+                <button
+                  type="button"
+                  className="secondary-button workspace-action-button"
+                  disabled={busy}
+                  onClick={() => void wrapCandidate(candidate.id, () => confirmMerge(candidate))}
+                >
+                  Merge
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </section>
+  );
+};

--- a/apps/web/src/components/EvidenceMediaSection.tsx
+++ b/apps/web/src/components/EvidenceMediaSection.tsx
@@ -3,13 +3,14 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createEvidenceMediaObject, listEvidenceMediaObjects } from "../lib/api";
-import type { MediaObjectRecord } from "../lib/api";
+import { createEvidenceMediaObject, listEvidenceMediaLinks, listEvidenceMediaObjects } from "../lib/api";
+import type { MediaLinkRecord, MediaObjectRecord } from "../lib/api";
 
 export const EvidenceMediaSection = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<MediaObjectRecord[]>([]);
+  const [linksByMediaId, setLinksByMediaId] = useState<Record<string, MediaLinkRecord[]>>({});
   const [storageUrl, setStorageUrl] = useState("");
   const [title, setTitle] = useState("");
   const [saving, setSaving] = useState(false);
@@ -21,6 +22,10 @@ export const EvidenceMediaSection = () => {
     try {
       const list = await listEvidenceMediaObjects();
       setItems(list);
+      const linkRows = await Promise.all(
+        list.map((item) => listEvidenceMediaLinks(item.id).then((links) => [item.id, links] as const))
+      );
+      setLinksByMediaId(Object.fromEntries(linkRows));
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load media");
     } finally {
@@ -122,6 +127,9 @@ export const EvidenceMediaSection = () => {
                     <a href={m.storageUrl} target="_blank" rel="noreferrer">
                       open
                     </a>
+                    {linksByMediaId[m.id]?.some((link) => link.targetType === "FAMILY") ? (
+                      <span className="hint"> · linked to family</span>
+                    ) : null}
                   </li>
                 ))}
               </ul>

--- a/apps/web/src/components/PersonDetailPanel.tsx
+++ b/apps/web/src/components/PersonDetailPanel.tsx
@@ -9,10 +9,12 @@ import type {
   Gender,
   Person,
   LifeEventRecord,
+  MediaObjectRecord,
   PatchFamilyBody,
   RelationshipRecord,
   RelationshipType,
   ResearchTaskRecord,
+  TargetMediaLinkRecord,
   TimelineEventRecord
 } from "../lib/api";
 import { immichPersonUrl, personThumbnailUrl } from "../lib/api";
@@ -122,6 +124,11 @@ type Props = {
   onFamilyPatch?: (familyId: string, body: PatchFamilyBody) => Promise<void>;
   onFamilyDelete?: (familyId: string) => Promise<void>;
   savingFamilyId?: string | null;
+  familyMediaLinksById?: Partial<Record<string, TargetMediaLinkRecord[]>>;
+  mediaObjects?: MediaObjectRecord[];
+  mediaManagementEnabled?: boolean;
+  onFamilyMediaLinkCreate?: (familyId: string, mediaObjectId: string) => Promise<void>;
+  onFamilyMediaLinkDelete?: (linkId: string) => Promise<void>;
   /** Cached family-scoped life events (residence/census/custom), keyed by family id */
   familyLifeEventsById?: Partial<Record<string, LifeEventRecord[]>>;
   onFamilyLifeEventCreate?: (familyId: string, body: CreateLifeEventBody) => Promise<void>;
@@ -212,6 +219,11 @@ const PersonDetailPanelComponent = ({
   onFamilyPatch,
   onFamilyDelete,
   savingFamilyId,
+  familyMediaLinksById,
+  mediaObjects,
+  mediaManagementEnabled,
+  onFamilyMediaLinkCreate,
+  onFamilyMediaLinkDelete,
   familyLifeEventsById,
   onFamilyLifeEventCreate,
   onFamilyLifeEventPatch,
@@ -844,6 +856,11 @@ const PersonDetailPanelComponent = ({
                 onPatchFamily={onFamilyPatch}
                 onDeleteFamily={onFamilyDelete}
                 savingFamilyId={savingFamilyId}
+                familyMediaLinksById={familyMediaLinksById}
+                mediaObjects={mediaObjects}
+                mediaManagementEnabled={mediaManagementEnabled}
+                onFamilyMediaLinkCreate={onFamilyMediaLinkCreate}
+                onFamilyMediaLinkDelete={onFamilyMediaLinkDelete}
                 familyLifeEventsById={familyLifeEventsById}
                 onFamilyLifeEventCreate={onFamilyLifeEventCreate}
                 onFamilyLifeEventPatch={onFamilyLifeEventPatch}

--- a/apps/web/src/components/ResearchWorkspace.tsx
+++ b/apps/web/src/components/ResearchWorkspace.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState } from "react";
+import type { ResearchTaskRecord, ValidationFindingRecord, ValidationFindingStatus } from "../lib/api";
+import { getPersonDisplayLabel } from "../lib/personDisplay";
+import type { Person } from "../lib/api";
+
+type Props = {
+  people: Person[];
+  tasks: ResearchTaskRecord[];
+  findings: ValidationFindingRecord[];
+  tasksLoading: boolean;
+  findingsLoading: boolean;
+  validationEngineDisabled: boolean;
+  onRefreshTasks: () => Promise<void>;
+  onRecomputeFindings: () => Promise<void>;
+  onTaskUpdate: (
+    taskId: string,
+    patch: Partial<Pick<ResearchTaskRecord, "status" | "dueDate">>
+  ) => Promise<void>;
+  onTaskDelete: (taskId: string) => Promise<void>;
+  onFindingStatusChange: (findingId: string, status: "OPEN" | "IN_PROGRESS" | "DISMISSED") => Promise<void>;
+  onOpenPerson: (personId: string) => void;
+};
+
+const activeTaskStatuses = new Set(["OPEN", "IN_PROGRESS"]);
+const activeFindingStatuses = new Set<ValidationFindingStatus>(["OPEN", "IN_PROGRESS"]);
+
+const personName = (people: Person[], personId: string | null | undefined) => {
+  if (!personId) {
+    return "Global";
+  }
+  const person = people.find((p) => p.id === personId);
+  return person ? getPersonDisplayLabel(person) : personId;
+};
+
+const openPersonIdForFinding = (finding: ValidationFindingRecord) =>
+  finding.personId ??
+  finding.relatedPersonId ??
+  finding.display.relationship?.fromPersonId ??
+  finding.display.relationship?.toPersonId ??
+  null;
+
+export const ResearchWorkspace = ({
+  people,
+  tasks,
+  findings,
+  tasksLoading,
+  findingsLoading,
+  validationEngineDisabled,
+  onRefreshTasks,
+  onRecomputeFindings,
+  onTaskUpdate,
+  onTaskDelete,
+  onFindingStatusChange,
+  onOpenPerson
+}: Props) => {
+  const [taskStatusFilter, setTaskStatusFilter] = useState<"ACTIVE" | "ALL">("ACTIVE");
+  const [findingStatusFilter, setFindingStatusFilter] = useState<"ACTIVE" | "ALL">("ACTIVE");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const visibleTasks = useMemo(
+    () =>
+      [...tasks]
+        .filter((task) => taskStatusFilter === "ALL" || activeTaskStatuses.has(task.status))
+        .sort(
+          (left, right) =>
+            left.status.localeCompare(right.status) ||
+            (left.dueDate ?? "9999-12-31").localeCompare(right.dueDate ?? "9999-12-31")
+        ),
+    [taskStatusFilter, tasks]
+  );
+
+  const visibleFindings = useMemo(
+    () =>
+      findings.filter(
+        (finding) => findingStatusFilter === "ALL" || activeFindingStatuses.has(finding.status)
+      ),
+    [findingStatusFilter, findings]
+  );
+
+  const wrap = async (fn: () => Promise<void>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Research action failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="workspace-main-stack workspace-main-stack--secondary">
+      <section className="card stack workspace-intro-card">
+        <div className="stack">
+          <h2>Research workspace</h2>
+          <p className="hint">Review open research tasks and persisted validation issues across the tree.</p>
+        </div>
+        {error ? <p className="hint hint--danger">{error}</p> : null}
+        {validationEngineDisabled ? (
+          <p className="hint hint--danger">
+            Validation engine is disabled. Stored findings remain visible, but recompute is unavailable.
+          </p>
+        ) : null}
+        <div className="workspace-action-row">
+          <span className="status-pill">Tasks: {visibleTasks.length}</span>
+          <span className="status-pill">Issues: {visibleFindings.length}</span>
+          <button
+            type="button"
+            className="secondary-button workspace-action-button"
+            disabled={busy || validationEngineDisabled}
+            onClick={() => void wrap(onRecomputeFindings)}
+          >
+            Recompute validation
+          </button>
+          <button
+            type="button"
+            className="secondary-button workspace-action-button"
+            disabled={busy}
+            onClick={() => void wrap(onRefreshTasks)}
+          >
+            Refresh tasks
+          </button>
+        </div>
+      </section>
+
+      <section className="card stack workspace-intro-card">
+        <div className="workspace-action-row">
+          <h3>Research tasks</h3>
+          <select
+            value={taskStatusFilter}
+            onChange={(event) => setTaskStatusFilter(event.target.value as "ACTIVE" | "ALL")}
+          >
+            <option value="ACTIVE">Open and in progress</option>
+            <option value="ALL">All statuses</option>
+          </select>
+        </div>
+        {tasksLoading ? <p className="hint">Loading tasks...</p> : null}
+        {!tasksLoading && visibleTasks.length === 0 ? (
+          <p className="hint">No matching research tasks.</p>
+        ) : null}
+        <ul className="research-task-list">
+          {visibleTasks.map((task) => (
+            <li key={task.id} className="research-task-item">
+              <select
+                value={task.status}
+                disabled={busy}
+                onChange={(event) =>
+                  void wrap(() =>
+                    onTaskUpdate(task.id, { status: event.target.value as ResearchTaskRecord["status"] })
+                  )
+                }
+              >
+                <option value="OPEN">OPEN</option>
+                <option value="IN_PROGRESS">IN_PROGRESS</option>
+                <option value="DONE">DONE</option>
+              </select>
+              <span className="research-task-title">{task.title}</span>
+              <span className="hint research-task-meta">{personName(people, task.personId)}</span>
+              <input
+                className="research-task-due-input"
+                type="date"
+                value={task.dueDate ?? ""}
+                disabled={busy}
+                onChange={(event) =>
+                  void wrap(() => onTaskUpdate(task.id, { dueDate: event.target.value || null }))
+                }
+              />
+              {task.personId ? (
+                <button
+                  type="button"
+                  className="text-link-button"
+                  onClick={() => onOpenPerson(task.personId!)}
+                >
+                  Open person
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="text-link-button"
+                disabled={busy}
+                onClick={() => void wrap(() => onTaskDelete(task.id))}
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="card stack workspace-intro-card">
+        <div className="workspace-action-row">
+          <h3>Validation issues</h3>
+          <select
+            value={findingStatusFilter}
+            onChange={(event) => setFindingStatusFilter(event.target.value as "ACTIVE" | "ALL")}
+          >
+            <option value="ACTIVE">Open and in progress</option>
+            <option value="ALL">All statuses</option>
+          </select>
+        </div>
+        {findingsLoading ? <p className="hint">Loading validation findings...</p> : null}
+        {!findingsLoading && visibleFindings.length === 0 ? (
+          <p className="hint">No matching validation issues.</p>
+        ) : null}
+        <ul className="research-task-list">
+          {visibleFindings.map((finding) => {
+            const openPersonId = openPersonIdForFinding(finding);
+            return (
+              <li key={finding.id} className="research-task-item">
+                <span className="status-pill">{finding.severity}</span>
+                <strong>{finding.code}</strong>
+                <span>{finding.message}</span>
+                <span className="hint research-task-meta">
+                  {finding.display.person?.label ??
+                    finding.display.relatedPerson?.label ??
+                    finding.display.relationship?.label ??
+                    finding.display.family?.label ??
+                    "Tree-wide"}
+                </span>
+                {openPersonId ? (
+                  <button
+                    type="button"
+                    className="text-link-button"
+                    onClick={() => onOpenPerson(openPersonId)}
+                  >
+                    Open person
+                  </button>
+                ) : null}
+                {finding.status !== "IN_PROGRESS" ? (
+                  <button
+                    type="button"
+                    className="text-link-button"
+                    disabled={busy}
+                    onClick={() => void wrap(() => onFindingStatusChange(finding.id, "IN_PROGRESS"))}
+                  >
+                    Mark in progress
+                  </button>
+                ) : null}
+                {finding.status === "DISMISSED" ? (
+                  <button
+                    type="button"
+                    className="text-link-button"
+                    disabled={busy}
+                    onClick={() => void wrap(() => onFindingStatusChange(finding.id, "OPEN"))}
+                  >
+                    Reopen
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="text-link-button"
+                    disabled={busy}
+                    onClick={() => void wrap(() => onFindingStatusChange(finding.id, "DISMISSED"))}
+                  >
+                    Dismiss
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </section>
+  );
+};

--- a/apps/web/src/components/personDetail/FamiliesSection.tsx
+++ b/apps/web/src/components/personDetail/FamiliesSection.tsx
@@ -1,9 +1,17 @@
 import { useState } from "react";
 import type { CreateLifeEventBody, PatchLifeEventBody } from "@treemich/shared";
-import type { FamilyRecord, Person, LifeEventRecord, PatchFamilyBody } from "../../lib/api";
+import type {
+  FamilyRecord,
+  Person,
+  LifeEventRecord,
+  MediaObjectRecord,
+  PatchFamilyBody,
+  TargetMediaLinkRecord
+} from "../../lib/api";
 import { getPersonDisplayLabel } from "../../lib/personDisplay";
 import { DestructiveConfirmDialog } from "../DestructiveConfirmDialog";
 import { FamilyLifeEventsBlock } from "./FamilyLifeEventsBlock";
+import { FamilyMediaLinksBlock } from "./FamilyMediaLinksBlock";
 
 type Props = {
   person: Person;
@@ -12,6 +20,11 @@ type Props = {
   onPatchFamily?: (familyId: string, body: PatchFamilyBody) => Promise<void>;
   onDeleteFamily?: (familyId: string) => Promise<void>;
   savingFamilyId?: string | null;
+  familyMediaLinksById?: Partial<Record<string, TargetMediaLinkRecord[]>>;
+  mediaObjects?: MediaObjectRecord[];
+  mediaManagementEnabled?: boolean;
+  onFamilyMediaLinkCreate?: (familyId: string, mediaObjectId: string) => Promise<void>;
+  onFamilyMediaLinkDelete?: (linkId: string) => Promise<void>;
   familyLifeEventsById?: Partial<Record<string, LifeEventRecord[]>>;
   onFamilyLifeEventCreate?: (familyId: string, body: CreateLifeEventBody) => Promise<void>;
   onFamilyLifeEventPatch?: (familyId: string, eventId: string, body: PatchLifeEventBody) => Promise<void>;
@@ -33,6 +46,11 @@ export const FamiliesSection = ({
   onPatchFamily,
   onDeleteFamily,
   savingFamilyId,
+  familyMediaLinksById,
+  mediaObjects = [],
+  mediaManagementEnabled = true,
+  onFamilyMediaLinkCreate,
+  onFamilyMediaLinkDelete,
   familyLifeEventsById,
   onFamilyLifeEventCreate,
   onFamilyLifeEventPatch,
@@ -217,6 +235,16 @@ export const FamiliesSection = ({
                     ) : null}
                   </div>
                 )}
+
+                <FamilyMediaLinksBlock
+                  familyId={family.id}
+                  links={familyMediaLinksById?.[family.id]}
+                  mediaObjects={mediaObjects}
+                  managementEnabled={mediaManagementEnabled}
+                  disabled={busy}
+                  onAttach={onFamilyMediaLinkCreate}
+                  onUnlink={onFamilyMediaLinkDelete}
+                />
 
                 <div className="field-group">
                   <span className="field-label">Children ({family.children.length})</span>

--- a/apps/web/src/components/personDetail/FamilyMediaLinksBlock.tsx
+++ b/apps/web/src/components/personDetail/FamilyMediaLinksBlock.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import type { MediaObjectRecord, TargetMediaLinkRecord } from "../../lib/api";
+
+type Props = {
+  familyId: string;
+  links: TargetMediaLinkRecord[] | undefined;
+  mediaObjects: MediaObjectRecord[];
+  managementEnabled: boolean;
+  disabled?: boolean;
+  onAttach?: (familyId: string, mediaObjectId: string) => Promise<void>;
+  onUnlink?: (linkId: string) => Promise<void>;
+};
+
+export const FamilyMediaLinksBlock = ({
+  familyId,
+  links,
+  mediaObjects,
+  managementEnabled,
+  disabled,
+  onAttach,
+  onUnlink
+}: Props) => {
+  const [selectedMediaId, setSelectedMediaId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const attach = async () => {
+    if (!selectedMediaId || !onAttach) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await onAttach(familyId, selectedMediaId);
+      setSelectedMediaId("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not attach media");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const unlink = async (linkId: string) => {
+    if (!onUnlink) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await onUnlink(linkId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not unlink media");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="field-group family-media-block">
+      <span className="field-label">Family media</span>
+      {error ? <p className="hint hint--danger">{error}</p> : null}
+      {links === undefined ? (
+        <p className="hint">Loading family media...</p>
+      ) : links.length === 0 ? (
+        <p className="hint">No media linked to this family.</p>
+      ) : (
+        <ul className="evidence-list">
+          {links.map((link) => (
+            <li key={link.id}>
+              <strong>{link.mediaObject.title?.trim() || "Untitled"}</strong>
+              {" · "}
+              <a href={link.mediaObject.storageUrl} target="_blank" rel="noreferrer">
+                open
+              </a>
+              {managementEnabled && onUnlink ? (
+                <>
+                  {" · "}
+                  <button
+                    type="button"
+                    className="text-link-button"
+                    disabled={disabled || busy}
+                    onClick={() => void unlink(link.id)}
+                  >
+                    Unlink
+                  </button>
+                </>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+      {managementEnabled ? (
+        <div className="family-unit-actions-inline">
+          <select
+            value={selectedMediaId}
+            disabled={disabled || busy || mediaObjects.length === 0}
+            onChange={(event) => setSelectedMediaId(event.target.value)}
+          >
+            <option value="">Attach existing media...</option>
+            {mediaObjects.map((media) => (
+              <option key={media.id} value={media.id}>
+                {media.title?.trim() || media.storageUrl}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={disabled || busy || !selectedMediaId}
+            onClick={() => void attach()}
+          >
+            Attach
+          </button>
+        </div>
+      ) : (
+        <p className="hint">Evidence management is disabled; existing links are read-only.</p>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/reports/ReportsWorkspace.spec.tsx
+++ b/apps/web/src/components/reports/ReportsWorkspace.spec.tsx
@@ -1,0 +1,105 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReportsWorkspace } from "./ReportsWorkspace";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchPedigreeReport: vi.fn(),
+  fetchDescendantReport: vi.fn(),
+  fetchFamilyGroupSheetReport: vi.fn(),
+  fetchRegisterReport: vi.fn(),
+  getFamilies: vi.fn(),
+  getFamiliesForPerson: vi.fn()
+}));
+
+vi.mock("../../lib/api", () => apiMocks);
+
+const reactTestEnvironment = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean };
+reactTestEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderWorkspace = (): { container: HTMLDivElement; root: Root } => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <ReportsWorkspace
+        selectedPersonId="p1"
+        people={[
+          { id: "p1", name: "Root Person" },
+          { id: "p2", name: "Other Person" }
+        ]}
+      />
+    );
+  });
+  return { container, root };
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("ReportsWorkspace", () => {
+  it("defaults to selected person and generates a pedigree report", async () => {
+    apiMocks.getFamiliesForPerson.mockResolvedValue([]);
+    apiMocks.fetchPedigreeReport.mockResolvedValue({
+      type: "pedigree",
+      generatedAt: "2026-04-29T00:00:00.000Z",
+      parameters: { rootPersonId: "p1", depth: 4, redactLiving: false },
+      warnings: [],
+      root: {
+        id: "p1",
+        displayName: "Root Person",
+        gender: "UNKNOWN",
+        primaryName: null,
+        alternateNames: [],
+        isLiving: true,
+        isRedacted: false,
+        events: []
+      },
+      generations: [{ generation: 0, people: [] }],
+      edges: []
+    });
+
+    const { container, root } = renderWorkspace();
+    await act(async () => {});
+
+    const generate = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Generate report")
+    );
+    await act(async () => {
+      generate?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(apiMocks.fetchPedigreeReport).toHaveBeenCalledWith("p1", { depth: 4, redactLiving: false });
+    expect(container.textContent).toContain("Pedigree chart");
+
+    act(() => root.unmount());
+  });
+
+  it("loads selected-person families for family group reports", async () => {
+    apiMocks.getFamiliesForPerson.mockResolvedValue([
+      {
+        id: "fam1",
+        parent1PersonId: "p1",
+        parent2PersonId: "p2",
+        children: [],
+        notes: null,
+        userId: "u1",
+        externalIds: {},
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z"
+      }
+    ]);
+    const { root } = renderWorkspace();
+    await act(async () => {});
+
+    expect(apiMocks.getFamiliesForPerson).toHaveBeenCalledWith(
+      "p1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    act(() => root.unmount());
+  });
+});

--- a/apps/web/src/components/reports/ReportsWorkspace.tsx
+++ b/apps/web/src/components/reports/ReportsWorkspace.tsx
@@ -1,0 +1,365 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  DescendantReportResponse,
+  FamilyGroupSheetResponse,
+  FamilyRecord,
+  PedigreeReportResponse,
+  Person,
+  RegisterReportResponse
+} from "../../lib/api";
+import {
+  fetchDescendantReport,
+  fetchFamilyGroupSheetReport,
+  fetchPedigreeReport,
+  fetchRegisterReport,
+  getFamilies,
+  getFamiliesForPerson
+} from "../../lib/api";
+import { getPersonDisplayLabel } from "../../lib/personDisplay";
+
+type ReportKind = "pedigree" | "descendants" | "family-group" | "register";
+type ReportResult =
+  | PedigreeReportResponse
+  | DescendantReportResponse
+  | FamilyGroupSheetResponse
+  | RegisterReportResponse;
+
+type Props = {
+  people: Person[];
+  selectedPersonId: string | null;
+};
+
+const reportLabels: Record<ReportKind, string> = {
+  pedigree: "Pedigree chart",
+  descendants: "Descendant chart",
+  "family-group": "Family group sheet",
+  register: "Register narrative"
+};
+
+const personName = (people: Person[], personId: string | null | undefined) => {
+  const person = people.find((p) => p.id === personId);
+  return person ? getPersonDisplayLabel(person) : (personId ?? "Unknown");
+};
+
+const familyLabel = (family: FamilyRecord, people: Person[]) => {
+  const parents = [family.parent1PersonId, family.parent2PersonId]
+    .filter(Boolean)
+    .map((id) => personName(people, id));
+  return parents.length > 0 ? parents.join(" + ") : `Family ${family.id.slice(0, 8)}`;
+};
+
+const EventList = ({
+  events
+}: {
+  events: ReportResult extends never ? never : PedigreeReportResponse["root"]["events"];
+}) => (
+  <ul className="report-event-list">
+    {events.map((event) => (
+      <li key={event.id}>
+        <strong>{event.label}</strong>
+        {event.dateDisplay ? `, ${event.dateDisplay}` : ""}
+        {event.placeDisplay ? `, ${event.placeDisplay}` : ""}
+        {event.citations.length > 0
+          ? ` (${event.citations.length} source${event.citations.length === 1 ? "" : "s"})`
+          : ""}
+      </li>
+    ))}
+  </ul>
+);
+
+const PersonCard = ({ person }: { person: PedigreeReportResponse["root"] }) => (
+  <article className="report-person-card">
+    <h4>{person.displayName}</h4>
+    <p className="hint">{person.isRedacted ? "Living person details redacted" : person.gender}</p>
+    <EventList events={person.events.slice(0, 4)} />
+  </article>
+);
+
+const ReportShell = ({ report, children }: { report: ReportResult; children: React.ReactNode }) => (
+  <section className="report-print-frame">
+    <div className="report-title-page">
+      <h2>{reportLabels[report.type]}</h2>
+      <p className="hint">
+        Generated {new Date(report.generatedAt).toLocaleString()} | Redact living:{" "}
+        {report.parameters.redactLiving ? "yes" : "no"}
+      </p>
+      {report.warnings.length > 0 ? (
+        <ul className="report-warning-list">
+          {report.warnings.map((warning, index) => (
+            <li key={`${warning.code}-${index}`}>{warning.message}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+    {children}
+  </section>
+);
+
+export const PedigreeReportView = ({ report }: { report: PedigreeReportResponse }) => (
+  <ReportShell report={report}>
+    <div className="pedigree-report-grid">
+      {report.generations.map((generation) => (
+        <section key={generation.generation} className="report-generation">
+          <h3>Generation {generation.generation}</h3>
+          {generation.people.map((person) => (
+            <PersonCard key={person.id} person={person} />
+          ))}
+        </section>
+      ))}
+    </div>
+  </ReportShell>
+);
+
+export const DescendantReportView = ({ report }: { report: DescendantReportResponse }) => (
+  <ReportShell report={report}>
+    {report.generations.map((generation) => (
+      <section key={generation.generation} className="report-section">
+        <h3>Generation {generation.generation}</h3>
+        {generation.families.map((family, index) => (
+          <article key={`${family.familyId ?? "fallback"}-${index}`} className="report-family-block">
+            <p>
+              <strong>Parents:</strong>{" "}
+              {family.parents.map((person) => person.displayName).join(", ") || "Unknown"}
+            </p>
+            <ul>
+              {family.children.map((child) => (
+                <li key={child.person.id}>
+                  {child.person.displayName}
+                  {child.pedigree ? ` (${child.pedigree.toLowerCase()})` : ""}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </section>
+    ))}
+  </ReportShell>
+);
+
+export const FamilyGroupSheetView = ({ report }: { report: FamilyGroupSheetResponse }) => (
+  <ReportShell report={report}>
+    <section className="report-section">
+      <h3>Parents</h3>
+      <div className="report-card-grid">
+        {report.family.parents.map((person) => (
+          <PersonCard key={person.id} person={person} />
+        ))}
+      </div>
+      <h3>Children</h3>
+      <table className="report-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Pedigree</th>
+            <th>Events</th>
+          </tr>
+        </thead>
+        <tbody>
+          {report.family.children.map((child) => (
+            <tr key={child.person.id}>
+              <td>{child.person.displayName}</td>
+              <td>{child.pedigree ?? ""}</td>
+              <td>{child.person.events.map((event) => event.label).join(", ")}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <h3>Family Events</h3>
+      <EventList events={report.family.events} />
+      {report.family.notes ? <p>{report.family.notes}</p> : null}
+    </section>
+  </ReportShell>
+);
+
+export const RegisterReportView = ({ report }: { report: RegisterReportResponse }) => (
+  <ReportShell report={report}>
+    {report.sections.map((section) => (
+      <article key={section.number} className="report-section">
+        <h3>
+          {section.number}. {section.person.displayName}
+        </h3>
+        {section.familySummaries.map((summary) => (
+          <p key={summary} className="hint">
+            {summary}
+          </p>
+        ))}
+        {section.prose.map((line) => (
+          <p key={line}>{line}</p>
+        ))}
+      </article>
+    ))}
+  </ReportShell>
+);
+
+const renderReport = (report: ReportResult) => {
+  switch (report.type) {
+    case "pedigree":
+      return <PedigreeReportView report={report} />;
+    case "descendants":
+      return <DescendantReportView report={report} />;
+    case "family-group":
+      return <FamilyGroupSheetView report={report} />;
+    case "register":
+      return <RegisterReportView report={report} />;
+  }
+};
+
+export const ReportsWorkspace = ({ people, selectedPersonId }: Props) => {
+  const [reportKind, setReportKind] = useState<ReportKind>("pedigree");
+  const [rootPersonId, setRootPersonId] = useState(selectedPersonId ?? people[0]?.id ?? "");
+  const [familyId, setFamilyId] = useState("");
+  const [families, setFamilies] = useState<FamilyRecord[]>([]);
+  const [depth, setDepth] = useState(4);
+  const [redactLiving, setRedactLiving] = useState(false);
+  const [report, setReport] = useState<ReportResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selectedPersonId) {
+      setRootPersonId(selectedPersonId);
+    }
+  }, [selectedPersonId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const load = selectedPersonId
+      ? getFamiliesForPerson(selectedPersonId, { signal: controller.signal })
+      : getFamilies({ signal: controller.signal });
+    load
+      .then((rows) => {
+        setFamilies(rows);
+        if (!familyId && rows[0]) {
+          setFamilyId(rows[0].id);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
+          setError(err instanceof Error ? err.message : "Could not load families");
+        }
+      });
+    return () => controller.abort();
+  }, [familyId, selectedPersonId]);
+
+  const sortedPeople = useMemo(
+    () =>
+      [...people].sort((left, right) =>
+        getPersonDisplayLabel(left).localeCompare(getPersonDisplayLabel(right))
+      ),
+    [people]
+  );
+
+  const canGenerate = reportKind === "family-group" ? familyId.length > 0 : rootPersonId.length > 0;
+
+  const generate = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const options = { depth, redactLiving };
+      const next =
+        reportKind === "pedigree"
+          ? await fetchPedigreeReport(rootPersonId, options)
+          : reportKind === "descendants"
+            ? await fetchDescendantReport(rootPersonId, options)
+            : reportKind === "register"
+              ? await fetchRegisterReport(rootPersonId, options)
+              : await fetchFamilyGroupSheetReport(familyId, { redactLiving });
+      setReport(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Report generation failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="workspace-main-stack workspace-main-stack--secondary reports-workspace">
+      <section className="card stack workspace-intro-card report-controls print-hidden">
+        <div className="stack">
+          <h2>Reports workspace</h2>
+          <p className="hint">Generate structured genealogy reports, then use browser print to save PDF.</p>
+        </div>
+        {error ? <p className="hint hint--danger">{error}</p> : null}
+        <div className="report-control-grid">
+          <label>
+            Report
+            <select value={reportKind} onChange={(event) => setReportKind(event.target.value as ReportKind)}>
+              {Object.entries(reportLabels).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {reportKind === "family-group" ? (
+            <label>
+              Family
+              <select value={familyId} onChange={(event) => setFamilyId(event.target.value)}>
+                <option value="">Select family</option>
+                {families.map((family) => (
+                  <option key={family.id} value={family.id}>
+                    {familyLabel(family, people)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : (
+            <>
+              <label>
+                Root person
+                <select value={rootPersonId} onChange={(event) => setRootPersonId(event.target.value)}>
+                  {sortedPeople.map((person) => (
+                    <option key={person.id} value={person.id}>
+                      {getPersonDisplayLabel(person)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Depth
+                <input
+                  type="number"
+                  min={1}
+                  max={6}
+                  value={depth}
+                  onChange={(event) => setDepth(Number(event.target.value))}
+                />
+              </label>
+            </>
+          )}
+          <label className="inline-checkbox">
+            <input
+              type="checkbox"
+              checked={redactLiving}
+              onChange={(event) => setRedactLiving(event.target.checked)}
+            />
+            Redact living
+          </label>
+        </div>
+        <div className="workspace-action-row">
+          <button
+            type="button"
+            className="primary-button"
+            disabled={!canGenerate || busy}
+            onClick={() => void generate()}
+          >
+            {busy ? "Generating..." : "Generate report"}
+          </button>
+          <button
+            type="button"
+            className="secondary-button"
+            disabled={!report}
+            onClick={() => window.print()}
+          >
+            Print / Save PDF
+          </button>
+        </div>
+      </section>
+      {report ? (
+        renderReport(report)
+      ) : (
+        <p className="hint">Choose report options and generate to preview printable output.</p>
+      )}
+    </section>
+  );
+};

--- a/apps/web/src/lib/api.spec.ts
+++ b/apps/web/src/lib/api.spec.ts
@@ -20,14 +20,21 @@ import {
   getPersonLifeEvents,
   immichPersonUrl,
   createEvidenceMediaObject,
+  createEvidenceMediaLink,
   createEvidenceRepository,
+  deleteEvidenceMediaLink,
+  getMediaLinksForTarget,
+  getValidationFindings,
   listEvidenceMediaObjects,
+  listEvidenceMediaLinks,
   listEvidenceRepositories,
   listEvidenceSources,
   login,
   logout,
   mergeEvidenceSources,
   patchFamily,
+  recomputeValidationFindings,
+  updateValidationFinding,
   updateFamilyLifeEvent
 } from "./api";
 
@@ -566,6 +573,139 @@ describe("evidence API helpers", () => {
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/evidence/media",
       expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("loads target media links for families", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          links: [
+            {
+              id: "link-1",
+              mediaObjectId: "m1",
+              targetType: "FAMILY",
+              targetId: "fam-1",
+              notes: null,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              mediaObject: {
+                id: "m1",
+                storageUrl: "family.jpg",
+                mimeType: "image/jpeg",
+                checksum: null,
+                immichAssetId: null,
+                title: "Family",
+                createdAt: "2026-01-01T00:00:00.000Z",
+                updatedAt: "2026-01-01T00:00:00.000Z"
+              }
+            }
+          ]
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const links = await getMediaLinksForTarget("FAMILY", "fam-1");
+    expect(links[0]?.mediaObject.title).toBe("Family");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/evidence/media-links?targetType=FAMILY&targetId=fam-1",
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("creates, lists, and deletes media links with session credentials", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "link-1", targetType: "FAMILY" }), {
+          status: 201,
+          headers: { "content-type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ links: [{ id: "link-1", targetType: "FAMILY" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await createEvidenceMediaLink("m1", { targetType: "FAMILY", targetId: "fam-1", notes: null });
+    await listEvidenceMediaLinks("m1");
+    await deleteEvidenceMediaLink("link-1");
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/evidence/media/m1/links",
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/evidence/media/m1/links",
+      expect.objectContaining({ cache: "no-store" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      3,
+      "/api/evidence/media-links/link-1",
+      expect.objectContaining({ method: "DELETE", credentials: "include" })
+    );
+  });
+});
+
+describe("validation findings API helpers", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("loads validation findings with repeated status filters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ findings: [{ id: "vf1", status: "OPEN" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+
+    const findings = await getValidationFindings({ status: ["OPEN", "IN_PROGRESS"] });
+    expect(findings).toHaveLength(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/validation/findings?status=OPEN&status=IN_PROGRESS",
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  it("recomputes and updates validation finding status via mutating routes", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ findings: [], summary: { current: 0 }, engineDisabled: false }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "vf1", status: "IN_PROGRESS" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+      );
+
+    await recomputeValidationFindings();
+    await updateValidationFinding("vf1", "IN_PROGRESS");
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/validation/recompute",
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/validation/findings/vf1",
+      expect.objectContaining({ method: "PATCH", body: JSON.stringify({ status: "IN_PROGRESS" }) })
     );
   });
 });

--- a/apps/web/src/lib/api.spec.ts
+++ b/apps/web/src/lib/api.spec.ts
@@ -11,6 +11,7 @@ import {
   deleteFamilyLifeEvent,
   getFamiliesForPerson,
   getFamilyLifeEvents,
+  getDuplicateCandidates,
   getPlacesMap,
   getPersonTimeline,
   getResearchTasks,
@@ -31,9 +32,12 @@ import {
   listEvidenceSources,
   login,
   logout,
+  mergeDuplicateCandidate,
   mergeEvidenceSources,
   patchFamily,
+  recomputeDuplicateCandidates,
   recomputeValidationFindings,
+  updateDuplicateCandidate,
   updateValidationFinding,
   updateFamilyLifeEvent
 } from "./api";
@@ -1080,5 +1084,76 @@ describe("people API helpers", () => {
     );
 
     await expect(deletePerson("missing")).rejects.toBeInstanceOf(ApiHttpError);
+  });
+
+  it("loads duplicate candidates with filters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ candidates: [{ id: "dup-1", status: "PENDING" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+
+    const candidates = await getDuplicateCandidates({ status: "PENDING", limit: 25 });
+
+    expect(candidates).toEqual([{ id: "dup-1", status: "PENDING" }]);
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0]?.[0])).toContain(
+      "/api/people/duplicates?status=PENDING&limit=25"
+    );
+  });
+
+  it("posts duplicate recompute, status update, and merge requests", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [],
+            summary: { created: 1, updated: 0, preservedDismissed: 0, pending: 1 }
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "dup-1", status: "DISMISSED" }), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ auditId: "audit-1", canonicalPersonId: "p1", duplicatePersonId: "p2" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" }
+          }
+        )
+      );
+
+    await recomputeDuplicateCandidates();
+    await updateDuplicateCandidate("dup-1", { status: "DISMISSED" });
+    await mergeDuplicateCandidate("dup-1", {
+      canonicalPersonId: "p1",
+      duplicatePersonId: "p2",
+      confirm: true
+    });
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/people/duplicates/recompute",
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/people/duplicates/dup-1",
+      expect.objectContaining({ method: "PATCH", credentials: "include" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      3,
+      "/api/people/duplicates/dup-1/merge",
+      expect.objectContaining({ method: "POST", credentials: "include" })
+    );
   });
 });

--- a/apps/web/src/lib/api.spec.ts
+++ b/apps/web/src/lib/api.spec.ts
@@ -10,6 +10,9 @@ import {
   deleteFamily,
   deleteFamilyLifeEvent,
   getFamiliesForPerson,
+  getFamilies,
+  fetchPedigreeReport,
+  fetchFamilyGroupSheetReport,
   getFamilyLifeEvents,
   getDuplicateCandidates,
   getPlacesMap,
@@ -769,6 +772,75 @@ describe("family API helpers", () => {
     expect(rows).toHaveLength(1);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/people/person%252F1/families",
+      expect.objectContaining({ credentials: "include", cache: "no-store" })
+    );
+  });
+
+  it("loads all families for report picker fallback", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ families: [{ id: "f1", children: [] }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    );
+
+    const rows = await getFamilies();
+    expect(rows).toHaveLength(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/families",
+      expect.objectContaining({ credentials: "include", cache: "no-store" })
+    );
+  });
+
+  it("loads report JSON helpers with query parameters", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            type: "pedigree",
+            generatedAt: "2026-04-29T00:00:00.000Z",
+            parameters: { rootPersonId: "p1", depth: 5, redactLiving: true },
+            warnings: [],
+            root: {
+              id: "p1",
+              displayName: "Living person",
+              gender: "UNKNOWN",
+              primaryName: null,
+              alternateNames: [],
+              isLiving: true,
+              isRedacted: true,
+              events: []
+            },
+            generations: [],
+            edges: []
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            type: "family-group",
+            generatedAt: "2026-04-29T00:00:00.000Z",
+            parameters: { familyId: "fam1", redactLiving: true },
+            warnings: [],
+            family: { id: "fam1", notes: null, parents: [], children: [], events: [], citations: [] }
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+
+    await fetchPedigreeReport("p1", { depth: 5, redactLiving: true });
+    await fetchFamilyGroupSheetReport("fam1", { redactLiving: true });
+
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/reports/pedigree?rootPersonId=p1&depth=5&redactLiving=true",
+      expect.objectContaining({ credentials: "include", cache: "no-store" })
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/reports/family-group?familyId=fam1&redactLiving=true",
       expect.objectContaining({ credentials: "include", cache: "no-store" })
     );
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   CreateFamilyBody,
   CreateFamilyLifeEventBody,
   CreateLifeEventBody,
+  CreateMediaLinkBody,
   CreateMediaObjectBody,
   CreatePersonNameBody,
   CreatePersonBody,
@@ -28,7 +29,9 @@ import type {
   LifeEventListResponse,
   LifeEventRecord,
   LinkStatus,
+  MediaLinkRecord,
   MediaObjectRecord,
+  MediaLinkTargetType,
   MergeSourcesBody,
   PatchFamilyBody,
   PatchLifeEventBody,
@@ -46,8 +49,12 @@ import type {
   SearchRelationshipsResponse,
   ResearchTaskRecord,
   SourceRecord,
+  TargetMediaLinkRecord,
   TreemichPersonProfile,
-  UserPreferences
+  UserPreferences,
+  ValidationFindingRecord,
+  ValidationFindingStatus,
+  ValidationRecomputeSummary
 } from "@treemich/shared";
 
 /** Re-exported `@treemich/shared` types for modules that depend only on the web API layer. */
@@ -57,6 +64,7 @@ export type {
   CreateFamilyBody,
   CreateFamilyLifeEventBody,
   CreateLifeEventBody,
+  CreateMediaLinkBody,
   CreateMediaObjectBody,
   CreatePersonBody,
   CreatePersonExternalIdentityBody,
@@ -74,6 +82,8 @@ export type {
   ImmichThumbnailImportResponse,
   LinkStatus,
   LifeEventRecord,
+  MediaLinkRecord,
+  MediaLinkTargetType,
   MediaObjectRecord,
   MergeSourcesBody,
   PatchFamilyBody,
@@ -92,8 +102,12 @@ export type {
   ResearchTaskRecord,
   SearchRelationshipsResponse,
   SourceRecord,
+  TargetMediaLinkRecord,
   TreemichPersonProfile,
-  UserPreferences
+  UserPreferences,
+  ValidationFindingRecord,
+  ValidationFindingStatus,
+  ValidationRecomputeSummary
 };
 
 const treemichApi = import.meta.env.VITE_TREEMICH_API_URL ?? "/api";
@@ -1116,6 +1130,84 @@ export const deleteResearchTask = async (taskId: string): Promise<void> => {
   await ensureOk(response, "Failed to delete research task");
 };
 
+export type ValidationFindingFilters = {
+  status?: ValidationFindingStatus[];
+  severity?: "error" | "warning";
+  code?: string;
+  personId?: string;
+  familyId?: string;
+};
+
+const validationFindingQuery = (filters?: ValidationFindingFilters) => {
+  const params = new URLSearchParams();
+  for (const status of filters?.status ?? []) {
+    params.append("status", status);
+  }
+  if (filters?.severity) {
+    params.set("severity", filters.severity);
+  }
+  if (filters?.code?.trim()) {
+    params.set("code", filters.code.trim());
+  }
+  if (filters?.personId) {
+    params.set("personId", filters.personId);
+  }
+  if (filters?.familyId) {
+    params.set("familyId", filters.familyId);
+  }
+  const query = params.toString();
+  return query ? `?${query}` : "";
+};
+
+export const getValidationFindings = async (
+  filters?: ValidationFindingFilters,
+  options?: RequestOptions
+): Promise<ValidationFindingRecord[]> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/validation/findings${validationFindingQuery(filters)}`,
+    {
+      cache: "no-store",
+      signal: options?.signal
+    }
+  );
+  await ensureOk(response, "Failed to load validation findings");
+  const body = (await response.json()) as { findings: ValidationFindingRecord[] };
+  return body.findings ?? [];
+};
+
+export const recomputeValidationFindings = async (): Promise<{
+  findings: ValidationFindingRecord[];
+  summary: ValidationRecomputeSummary;
+  engineDisabled: boolean;
+}> => {
+  const response = await fetch(
+    `${treemichApi}/validation/recompute`,
+    withSession({ method: "POST", headers: { "Content-Type": "application/json" } })
+  );
+  await ensureOk(response, "Failed to recompute validation findings");
+  return (await response.json()) as {
+    findings: ValidationFindingRecord[];
+    summary: ValidationRecomputeSummary;
+    engineDisabled: boolean;
+  };
+};
+
+export const updateValidationFinding = async (
+  findingId: string,
+  status: "OPEN" | "IN_PROGRESS" | "DISMISSED"
+): Promise<ValidationFindingRecord> => {
+  const response = await fetch(
+    `${treemichApi}/validation/findings/${encodeURIComponent(findingId)}`,
+    withSession({
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status })
+    })
+  );
+  await ensureOk(response, "Failed to update validation finding");
+  return (await response.json()) as ValidationFindingRecord;
+};
+
 /** `GET /evidence/repositories` — archives / libraries for grouping sources. */
 export const listEvidenceRepositories = async (): Promise<RepositoryRecord[]> => {
   const response = await fetchWithRetry(`${treemichApi}/evidence/repositories`, { cache: "no-store" });
@@ -1194,6 +1286,58 @@ export const createEvidenceMediaObject = async (body: CreateMediaObjectBody): Pr
   );
   await ensureOk(response, "Failed to create media object");
   return (await response.json()) as MediaObjectRecord;
+};
+
+export const getMediaLinksForTarget = async (
+  targetType: MediaLinkTargetType,
+  targetId: string,
+  options?: RequestOptions
+): Promise<TargetMediaLinkRecord[]> => {
+  const query = new URLSearchParams({ targetType, targetId });
+  const response = await fetchWithRetry(`${treemichApi}/evidence/media-links?${query.toString()}`, {
+    cache: "no-store",
+    signal: options?.signal
+  });
+  await ensureOk(response, "Failed to load media links");
+  const body = (await response.json()) as { links: TargetMediaLinkRecord[] };
+  return body.links ?? [];
+};
+
+export const listEvidenceMediaLinks = async (
+  mediaObjectId: string,
+  options?: RequestOptions
+): Promise<MediaLinkRecord[]> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/evidence/media/${encodeURIComponent(mediaObjectId)}/links`,
+    { cache: "no-store", signal: options?.signal }
+  );
+  await ensureOk(response, "Failed to load media object links");
+  const body = (await response.json()) as { links: MediaLinkRecord[] };
+  return body.links ?? [];
+};
+
+export const createEvidenceMediaLink = async (
+  mediaObjectId: string,
+  body: CreateMediaLinkBody
+): Promise<MediaLinkRecord> => {
+  const response = await fetch(
+    `${treemichApi}/evidence/media/${encodeURIComponent(mediaObjectId)}/links`,
+    withSession({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    })
+  );
+  await ensureOk(response, "Failed to create media link");
+  return (await response.json()) as MediaLinkRecord;
+};
+
+export const deleteEvidenceMediaLink = async (linkId: string): Promise<void> => {
+  const response = await fetch(
+    `${treemichApi}/evidence/media-links/${encodeURIComponent(linkId)}`,
+    withSession({ method: "DELETE" })
+  );
+  await ensureOk(response, "Failed to delete media link");
 };
 
 /** `POST /import/gedcom/preview` — parse UTF-8 GEDCOM and list INDI/FAM for matching (Phase 5b). */

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -48,6 +48,10 @@ import type {
   PersonRecord,
   PhotoCluster,
   PhotoCooccurrenceEdge,
+  PedigreeReportResponse,
+  DescendantReportResponse,
+  FamilyGroupSheetResponse,
+  RegisterReportResponse,
   RelationshipRecord,
   RelationshipType,
   RepositoryRecord,
@@ -106,6 +110,10 @@ export type {
   PersonRecord,
   PhotoCluster,
   PhotoCooccurrenceEdge,
+  PedigreeReportResponse,
+  DescendantReportResponse,
+  FamilyGroupSheetResponse,
+  RegisterReportResponse,
   RelationshipRecord,
   RelationshipType,
   RepositoryRecord,
@@ -1068,6 +1076,91 @@ export const getFamiliesForPerson = async (
   await ensureOk(response, "Failed to load families");
   const body = (await response.json()) as { families: FamilyRecord[] };
   return body.families ?? [];
+};
+
+/** `GET /families` — all family units for picker fallback. */
+export const getFamilies = async (options?: RequestOptions): Promise<FamilyRecord[]> => {
+  const response = await fetchWithRetry(`${treemichApi}/families`, {
+    cache: "no-store",
+    signal: options?.signal
+  });
+  await ensureOk(response, "Failed to load families");
+  const body = (await response.json()) as { families: FamilyRecord[] };
+  return body.families ?? [];
+};
+
+type ReportQueryOptions = {
+  redactLiving?: boolean;
+  depth?: number;
+} & RequestOptions;
+
+const reportDepthQuery = (rootPersonId: string, options?: ReportQueryOptions) => {
+  const params = new URLSearchParams({ rootPersonId });
+  if (options?.depth != null) {
+    params.set("depth", String(options.depth));
+  }
+  if (options?.redactLiving === true) {
+    params.set("redactLiving", "true");
+  }
+  return params.toString();
+};
+
+export const fetchPedigreeReport = async (
+  rootPersonId: string,
+  options?: ReportQueryOptions
+): Promise<PedigreeReportResponse> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/reports/pedigree?${reportDepthQuery(rootPersonId, options)}`,
+    {
+      cache: "no-store",
+      signal: options?.signal
+    }
+  );
+  await ensureOk(response, "Failed to load pedigree report");
+  return (await response.json()) as PedigreeReportResponse;
+};
+
+export const fetchDescendantReport = async (
+  rootPersonId: string,
+  options?: ReportQueryOptions
+): Promise<DescendantReportResponse> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/reports/descendants?${reportDepthQuery(rootPersonId, options)}`,
+    { cache: "no-store", signal: options?.signal }
+  );
+  await ensureOk(response, "Failed to load descendant report");
+  return (await response.json()) as DescendantReportResponse;
+};
+
+export const fetchRegisterReport = async (
+  rootPersonId: string,
+  options?: ReportQueryOptions
+): Promise<RegisterReportResponse> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/reports/register?${reportDepthQuery(rootPersonId, options)}`,
+    {
+      cache: "no-store",
+      signal: options?.signal
+    }
+  );
+  await ensureOk(response, "Failed to load register report");
+  return (await response.json()) as RegisterReportResponse;
+};
+
+export const fetchFamilyGroupSheetReport = async (
+  familyId: string,
+  options?: { redactLiving?: boolean } & RequestOptions
+): Promise<FamilyGroupSheetResponse> => {
+  const params = new URLSearchParams({ familyId });
+  if (options?.redactLiving === true) {
+    params.set("redactLiving", "true");
+  }
+  const response = await fetchWithRetry(`${treemichApi}/reports/family-group?${params.toString()}`, {
+    cache: "no-store",
+    signal: options?.signal
+  });
+  await ensureOk(response, "Failed to load family group sheet report");
+  return (await response.json()) as FamilyGroupSheetResponse;
 };
 
 /** `POST /families` — create a family union; server derives parent/child graph edges. */

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,11 +33,16 @@ import type {
   MediaObjectRecord,
   MediaLinkTargetType,
   MergeSourcesBody,
+  MergePeopleBody,
   PatchFamilyBody,
   PatchLifeEventBody,
+  PatchPersonDuplicateCandidateBody,
   PatchPersonNameBody,
   PatchResearchTaskBody,
   PersonNameTypeValue,
+  PersonDuplicateCandidateRecord,
+  PersonDuplicateRecomputeResponse,
+  PersonMergeResult,
   PersonExternalIdentityRecord,
   PersonThumbnailRecord,
   PersonRecord,
@@ -86,11 +91,16 @@ export type {
   MediaLinkTargetType,
   MediaObjectRecord,
   MergeSourcesBody,
+  MergePeopleBody,
   PatchFamilyBody,
   PatchLifeEventBody,
+  PatchPersonDuplicateCandidateBody,
   PatchPersonNameBody,
   PatchResearchTaskBody,
   PersonNameTypeValue,
+  PersonDuplicateCandidateRecord,
+  PersonDuplicateRecomputeResponse,
+  PersonMergeResult,
   PersonExternalIdentityRecord,
   PersonThumbnailRecord,
   PersonRecord,
@@ -345,6 +355,84 @@ export const deletePerson = async (personId: string): Promise<void> => {
     })
   );
   await ensureOk(response, "Failed to delete person");
+};
+
+export type DuplicateCandidateFilters = {
+  status?: "PENDING" | "DISMISSED" | "MERGED";
+  limit?: number;
+  offset?: number;
+};
+
+const duplicateCandidateQuery = (filters?: DuplicateCandidateFilters) => {
+  const params = new URLSearchParams();
+  if (filters?.status) {
+    params.set("status", filters.status);
+  }
+  if (filters?.limit != null) {
+    params.set("limit", String(filters.limit));
+  }
+  if (filters?.offset != null) {
+    params.set("offset", String(filters.offset));
+  }
+  const query = params.toString();
+  return query ? `?${query}` : "";
+};
+
+export const getDuplicateCandidates = async (
+  filters?: DuplicateCandidateFilters,
+  options?: RequestOptions
+): Promise<PersonDuplicateCandidateRecord[]> => {
+  const response = await fetchWithRetry(
+    `${treemichApi}/people/duplicates${duplicateCandidateQuery(filters)}`,
+    {
+      cache: "no-store",
+      signal: options?.signal
+    }
+  );
+  await ensureOk(response, "Failed to load duplicate candidates");
+  const body = (await response.json()) as { candidates?: PersonDuplicateCandidateRecord[] };
+  return body.candidates ?? [];
+};
+
+export const recomputeDuplicateCandidates = async (): Promise<PersonDuplicateRecomputeResponse> => {
+  const response = await fetch(
+    `${treemichApi}/people/duplicates/recompute`,
+    withSession({ method: "POST", headers: { "Content-Type": "application/json" } })
+  );
+  await ensureOk(response, "Failed to recompute duplicate candidates");
+  return (await response.json()) as PersonDuplicateRecomputeResponse;
+};
+
+export const updateDuplicateCandidate = async (
+  candidateId: string,
+  body: PatchPersonDuplicateCandidateBody
+): Promise<PersonDuplicateCandidateRecord> => {
+  const response = await fetch(
+    `${treemichApi}/people/duplicates/${encodeURIComponent(candidateId)}`,
+    withSession({
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    })
+  );
+  await ensureOk(response, "Failed to update duplicate candidate");
+  return (await response.json()) as PersonDuplicateCandidateRecord;
+};
+
+export const mergeDuplicateCandidate = async (
+  candidateId: string,
+  body: MergePeopleBody
+): Promise<PersonMergeResult> => {
+  const response = await fetch(
+    `${treemichApi}/people/duplicates/${encodeURIComponent(candidateId)}/merge`,
+    withSession({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    })
+  );
+  await ensureOk(response, "Failed to merge people");
+  return (await response.json()) as PersonMergeResult;
 };
 
 /** `PATCH /people/:id` — Treemich profile fields (gender, names, etc.). */

--- a/apps/web/src/pages/people-page.integration.spec.tsx
+++ b/apps/web/src/pages/people-page.integration.spec.tsx
@@ -654,7 +654,7 @@ describe("PeoplePage + life events (integration)", () => {
     container.remove();
   });
 
-  it("renders Settings search preferences and disables planned workspaces", async () => {
+  it("renders Settings search preferences and keeps only Reports disabled as planned work", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -667,8 +667,8 @@ describe("PeoplePage + life events (integration)", () => {
     const reportsNav = container.querySelector('[data-workspace="reports"]') as HTMLButtonElement | null;
     const settingsNav = container.querySelector('[data-workspace="settings"]') as HTMLButtonElement | null;
 
-    expect(researchNav?.disabled).toBe(true);
-    expect(researchNav?.title).toBe("Planned for Phase C");
+    expect(researchNav?.disabled).toBe(false);
+    expect(researchNav?.title).toBe("");
     expect(reportsNav?.disabled).toBe(true);
     expect(reportsNav?.title).toBe("Planned for Phase E");
     expect(settingsNav?.disabled).toBe(false);

--- a/apps/web/src/pages/people-page.integration.spec.tsx
+++ b/apps/web/src/pages/people-page.integration.spec.tsx
@@ -654,7 +654,7 @@ describe("PeoplePage + life events (integration)", () => {
     container.remove();
   });
 
-  it("renders Settings search preferences and keeps only Reports disabled as planned work", async () => {
+  it("renders Settings search preferences and keeps Reports enabled", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -669,8 +669,8 @@ describe("PeoplePage + life events (integration)", () => {
 
     expect(researchNav?.disabled).toBe(false);
     expect(researchNav?.title).toBe("");
-    expect(reportsNav?.disabled).toBe(true);
-    expect(reportsNav?.title).toBe("Planned for Phase E");
+    expect(reportsNav?.disabled).toBe(false);
+    expect(reportsNav?.title).toBe("");
     expect(settingsNav?.disabled).toBe(false);
 
     await act(async () => {

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -102,6 +102,7 @@ import { ImmichImportWorkspace } from "../components/ImmichImportWorkspace";
 import { PersonDetailPanel } from "../components/PersonDetailPanel";
 import { ResearchWorkspace } from "../components/ResearchWorkspace";
 import { DuplicateReviewWorkspace } from "../components/DuplicateReviewWorkspace";
+import { ReportsWorkspace } from "../components/reports/ReportsWorkspace";
 import { CreatePersonDialog } from "../components/CreatePersonDialog";
 import { MapPlacesPanel } from "../components/MapPlacesPanel";
 import { PeopleGraph3D } from "../components/PeopleGraph3D";
@@ -139,7 +140,7 @@ const WORKSPACE_ITEMS: WorkspaceItem[] = [
   { id: "evidence", label: "Evidence", iconLabel: "EV" },
   { id: "interchange", label: "Interchange", iconLabel: "GX" },
   { id: "places", label: "Places", iconLabel: "MP" },
-  { id: "reports", label: "Reports", iconLabel: "RP", disabledReason: "Planned for Phase E" },
+  { id: "reports", label: "Reports", iconLabel: "RP" },
   { id: "settings", label: "Settings", iconLabel: "ST" }
 ];
 
@@ -2324,16 +2325,7 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
     }
 
     if (activeWorkspace === "reports") {
-      return (
-        <section className="workspace-main-stack workspace-main-stack--secondary">
-          <section className="card stack workspace-intro-card">
-            <h2>Reports workspace</h2>
-            <p className="hint">
-              Planned for Phase E. Printable charts, PDFs, and family sheets are not active yet.
-            </p>
-          </section>
-        </section>
-      );
+      return <ReportsWorkspace people={people} selectedPersonId={selectedPerson?.id ?? null} />;
     }
 
     if (activeWorkspace === "settings") {

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -20,13 +20,16 @@ import type {
   GraphLayoutResponse,
   PersonRecord,
   LifeEventRecord,
+  MediaObjectRecord,
   PatchFamilyBody,
   PlacesMapPoint,
   ResearchTaskRecord,
   RelationshipRecord,
   TimelineEventRecord,
   RelationshipType,
-  UserPreferences
+  UserPreferences,
+  TargetMediaLinkRecord,
+  ValidationFindingRecord
 } from "../lib/api";
 import {
   createPerson,
@@ -35,13 +38,18 @@ import {
   createPersonLifeEvent,
   createRelationshipLifeEvent,
   createFamilyLifeEvent,
+  createEvidenceMediaLink,
   computeGraphLayout,
   createRelationship,
   deleteFamily,
   deleteFamilyLifeEvent,
+  deleteEvidenceMediaLink,
   deleteResearchTask,
   getFamiliesForPerson,
   getFamilyLifeEvents,
+  getMediaLinksForTarget,
+  getValidationFindings,
+  listEvidenceMediaObjects,
   deletePersonLifeEvent,
   deletePerson,
   deletePersonExternalIdentity,
@@ -64,7 +72,9 @@ import {
   updateResearchTask,
   updateRelationshipLifeEvent,
   updatePersonProfile,
-  updateUserPreferences
+  updateUserPreferences,
+  recomputeValidationFindings,
+  updateValidationFinding
 } from "../lib/api";
 import {
   buildBirthPlaceInput,
@@ -85,6 +95,7 @@ import { EvidenceMediaSection } from "../components/EvidenceMediaSection";
 import { GedcomInterchangeSection } from "../components/GedcomInterchangeSection";
 import { ImmichImportWorkspace } from "../components/ImmichImportWorkspace";
 import { PersonDetailPanel } from "../components/PersonDetailPanel";
+import { ResearchWorkspace } from "../components/ResearchWorkspace";
 import { CreatePersonDialog } from "../components/CreatePersonDialog";
 import { MapPlacesPanel } from "../components/MapPlacesPanel";
 import { PeopleGraph3D } from "../components/PeopleGraph3D";
@@ -109,7 +120,7 @@ type WorkspaceItem = {
 
 const WORKSPACE_ITEMS: WorkspaceItem[] = [
   { id: "tree", label: "Tree", iconLabel: "TR" },
-  { id: "research", label: "Research", iconLabel: "RS", disabledReason: "Planned for Phase C" },
+  { id: "research", label: "Research", iconLabel: "RS" },
   { id: "evidence", label: "Evidence", iconLabel: "EV" },
   { id: "interchange", label: "Interchange", iconLabel: "GX" },
   { id: "places", label: "Places", iconLabel: "MP" },
@@ -450,10 +461,18 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
   const [researchTasksByPersonId, setResearchTasksByPersonId] = useState<
     Record<string, ResearchTaskRecord[]>
   >({});
+  const [allResearchTasks, setAllResearchTasks] = useState<ResearchTaskRecord[]>([]);
+  const [allResearchTasksLoading, setAllResearchTasksLoading] = useState(false);
+  const [validationFindings, setValidationFindings] = useState<ValidationFindingRecord[]>([]);
+  const [validationFindingsLoading, setValidationFindingsLoading] = useState(false);
   const [familiesByPersonId, setFamiliesByPersonId] = useState<Record<string, FamilyRecord[] | undefined>>(
     {}
   );
   const [savingFamilyId, setSavingFamilyId] = useState<string | null>(null);
+  const [familyMediaLinksById, setFamilyMediaLinksById] = useState<
+    Partial<Record<string, TargetMediaLinkRecord[]>>
+  >({});
+  const [evidenceMediaObjects, setEvidenceMediaObjects] = useState<MediaObjectRecord[]>([]);
   const [familyLifeEventsById, setFamilyLifeEventsById] = useState<
     Partial<Record<string, LifeEventRecord[]>>
   >({});
@@ -935,6 +954,67 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
       controller.abort();
     };
   }, [familyLifeEventsById, familiesForSelected, selectedPerson]);
+
+  useEffect(() => {
+    const fams = familiesForSelected;
+    if (fams === undefined) {
+      return;
+    }
+    const toFetch = fams.map((f) => f.id).filter((id) => familyMediaLinksById[id] === undefined);
+    if (toFetch.length === 0) {
+      return;
+    }
+    const controller = new AbortController();
+    Promise.all(
+      toFetch.map((id) =>
+        getMediaLinksForTarget("FAMILY", id, { signal: controller.signal }).then(
+          (links) => [id, links] as const
+        )
+      )
+    )
+      .then((rows) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setFamilyMediaLinksById((current) => {
+          const next = { ...current };
+          for (const [id, links] of rows) {
+            next[id] = links;
+          }
+          return next;
+        });
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted || isAbortError(err)) {
+          return;
+        }
+        setStatus(`Could not load family media: ${getErrorMessage(err)}`);
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [familiesForSelected, familyMediaLinksById]);
+
+  useEffect(() => {
+    if (import.meta.env.VITE_EVIDENCE_MANAGEMENT_UI === "false") {
+      return;
+    }
+    let cancelled = false;
+    listEvidenceMediaObjects()
+      .then((items) => {
+        if (!cancelled) {
+          setEvidenceMediaObjects(items);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setStatus(`Could not load evidence media: ${getErrorMessage(err)}`);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!selectedPersonId) {
@@ -1680,16 +1760,49 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
     }));
   }, [selectedPerson]);
 
+  const refreshAllResearchTasks = useCallback(async () => {
+    setAllResearchTasksLoading(true);
+    try {
+      const tasks = await getResearchTasks();
+      setAllResearchTasks(tasks);
+    } finally {
+      setAllResearchTasksLoading(false);
+    }
+  }, []);
+
+  const refreshValidationFindings = useCallback(async () => {
+    setValidationFindingsLoading(true);
+    try {
+      const findings = await getValidationFindings();
+      setValidationFindings(findings);
+    } finally {
+      setValidationFindingsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeWorkspace !== "research") {
+      return;
+    }
+    void refreshAllResearchTasks().catch((err: unknown) => {
+      setStatus(`Could not load all research tasks: ${getErrorMessage(err)}`);
+    });
+    void refreshValidationFindings().catch((err: unknown) => {
+      setStatus(`Could not load validation findings: ${getErrorMessage(err)}`);
+    });
+  }, [activeWorkspace, refreshAllResearchTasks, refreshValidationFindings]);
+
   const handleResearchTaskCreate = useCallback(
     async (body: CreateResearchTaskBody) => {
       try {
         await createResearchTask(body);
         await refreshResearchTasksForSelectedPerson();
+        await refreshAllResearchTasks();
       } catch (error: unknown) {
         setStatus(getErrorMessage(error));
       }
     },
-    [refreshResearchTasksForSelectedPerson]
+    [refreshAllResearchTasks, refreshResearchTasksForSelectedPerson]
   );
 
   const handleResearchTaskUpdate = useCallback(
@@ -1700,11 +1813,12 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
       try {
         await updateResearchTask(taskId, patch);
         await refreshResearchTasksForSelectedPerson();
+        await refreshAllResearchTasks();
       } catch (error: unknown) {
         setStatus(getErrorMessage(error));
       }
     },
-    [refreshResearchTasksForSelectedPerson]
+    [refreshAllResearchTasks, refreshResearchTasksForSelectedPerson]
   );
 
   const handleResearchTaskDelete = useCallback(
@@ -1712,11 +1826,60 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
       try {
         await deleteResearchTask(taskId);
         await refreshResearchTasksForSelectedPerson();
+        await refreshAllResearchTasks();
       } catch (error: unknown) {
         setStatus(getErrorMessage(error));
       }
     },
-    [refreshResearchTasksForSelectedPerson]
+    [refreshAllResearchTasks, refreshResearchTasksForSelectedPerson]
+  );
+
+  const handleValidationRecompute = useCallback(async () => {
+    const result = await recomputeValidationFindings();
+    setValidationFindings(result.findings);
+    setTreeValidationIssueCount(result.findings.filter((finding) => finding.status !== "RESOLVED").length);
+    setTreeValidationEngineDisabled(result.engineDisabled);
+    setStatus(`Validation recomputed: ${result.summary.current} current issue(s)`);
+  }, []);
+
+  const handleValidationFindingStatusChange = useCallback(
+    async (findingId: string, nextStatus: "OPEN" | "IN_PROGRESS" | "DISMISSED") => {
+      await updateValidationFinding(findingId, nextStatus);
+      await refreshValidationFindings();
+    },
+    [refreshValidationFindings]
+  );
+
+  const openPersonFromResearch = useCallback((personId: string) => {
+    setSelectedPersonId(personId);
+    setGraphCameraFocusPersonId(personId);
+    setActiveWorkspace("tree");
+  }, []);
+
+  const refreshFamilyMediaLinks = useCallback(async (familyId: string) => {
+    const links = await getMediaLinksForTarget("FAMILY", familyId);
+    setFamilyMediaLinksById((current) => ({ ...current, [familyId]: links }));
+  }, []);
+
+  const handleFamilyMediaLinkCreate = useCallback(
+    async (familyId: string, mediaObjectId: string) => {
+      await createEvidenceMediaLink(mediaObjectId, { targetType: "FAMILY", targetId: familyId });
+      await refreshFamilyMediaLinks(familyId);
+    },
+    [refreshFamilyMediaLinks]
+  );
+
+  const handleFamilyMediaLinkDelete = useCallback(
+    async (linkId: string) => {
+      await deleteEvidenceMediaLink(linkId);
+      for (const [familyId, links] of Object.entries(familyMediaLinksById)) {
+        if (links?.some((link) => link.id === linkId)) {
+          await refreshFamilyMediaLinks(familyId);
+          break;
+        }
+      }
+    },
+    [familyMediaLinksById, refreshFamilyMediaLinks]
   );
 
   const handleRelationshipLifeEventCreate = useCallback(
@@ -2061,14 +2224,20 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
 
     if (activeWorkspace === "research") {
       return (
-        <section className="workspace-main-stack workspace-main-stack--secondary">
-          <section className="card stack workspace-intro-card">
-            <h2>Research workspace</h2>
-            <p className="hint">
-              Planned for Phase C. Research tasks remain available in the tree inspector.
-            </p>
-          </section>
-        </section>
+        <ResearchWorkspace
+          people={people}
+          tasks={allResearchTasks}
+          findings={validationFindings}
+          tasksLoading={allResearchTasksLoading}
+          findingsLoading={validationFindingsLoading}
+          validationEngineDisabled={treeValidationEngineDisabled}
+          onRefreshTasks={refreshAllResearchTasks}
+          onRecomputeFindings={handleValidationRecompute}
+          onTaskUpdate={handleResearchTaskUpdate}
+          onTaskDelete={handleResearchTaskDelete}
+          onFindingStatusChange={handleValidationFindingStatusChange}
+          onOpenPerson={openPersonFromResearch}
+        />
       );
     }
 
@@ -2303,6 +2472,11 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
           onFamilyPatch: handleFamilyPatch,
           onFamilyDelete: handleFamilyDelete,
           savingFamilyId,
+          familyMediaLinksById,
+          mediaObjects: evidenceMediaObjects,
+          mediaManagementEnabled: import.meta.env.VITE_EVIDENCE_MANAGEMENT_UI !== "false",
+          onFamilyMediaLinkCreate: handleFamilyMediaLinkCreate,
+          onFamilyMediaLinkDelete: handleFamilyMediaLinkDelete,
           familyLifeEventsById,
           onFamilyLifeEventCreate: handleFamilyLifeEventCreate,
           onFamilyLifeEventPatch: handleFamilyLifeEventPatch,

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -25,6 +25,7 @@ import type {
   PlacesMapPoint,
   ResearchTaskRecord,
   RelationshipRecord,
+  PersonDuplicateCandidateRecord,
   TimelineEventRecord,
   RelationshipType,
   UserPreferences,
@@ -56,6 +57,7 @@ import {
   deleteRelationship,
   deleteRelationshipLifeEvent,
   getPeople,
+  getDuplicateCandidates,
   getPlacesMap,
   getPersonLifeEvents,
   getPersonTimeline,
@@ -74,7 +76,10 @@ import {
   updatePersonProfile,
   updateUserPreferences,
   recomputeValidationFindings,
-  updateValidationFinding
+  updateValidationFinding,
+  recomputeDuplicateCandidates,
+  updateDuplicateCandidate,
+  mergeDuplicateCandidate
 } from "../lib/api";
 import {
   buildBirthPlaceInput,
@@ -96,6 +101,7 @@ import { GedcomInterchangeSection } from "../components/GedcomInterchangeSection
 import { ImmichImportWorkspace } from "../components/ImmichImportWorkspace";
 import { PersonDetailPanel } from "../components/PersonDetailPanel";
 import { ResearchWorkspace } from "../components/ResearchWorkspace";
+import { DuplicateReviewWorkspace } from "../components/DuplicateReviewWorkspace";
 import { CreatePersonDialog } from "../components/CreatePersonDialog";
 import { MapPlacesPanel } from "../components/MapPlacesPanel";
 import { PeopleGraph3D } from "../components/PeopleGraph3D";
@@ -109,7 +115,15 @@ const CONTEXT_OPEN_STORAGE_KEY = "treemich.contextOpen";
 const GRAPH_UI_STATE_STORAGE_KEY = "treemich.graph.uiState";
 const MAP_UI_STATE_STORAGE_KEY = "treemich.map.uiState";
 
-type WorkspaceId = "tree" | "research" | "evidence" | "interchange" | "places" | "reports" | "settings";
+type WorkspaceId =
+  | "tree"
+  | "duplicates"
+  | "research"
+  | "evidence"
+  | "interchange"
+  | "places"
+  | "reports"
+  | "settings";
 
 type WorkspaceItem = {
   id: WorkspaceId;
@@ -120,6 +134,7 @@ type WorkspaceItem = {
 
 const WORKSPACE_ITEMS: WorkspaceItem[] = [
   { id: "tree", label: "Tree", iconLabel: "TR" },
+  { id: "duplicates", label: "Duplicates", iconLabel: "DQ" },
   { id: "research", label: "Research", iconLabel: "RS" },
   { id: "evidence", label: "Evidence", iconLabel: "EV" },
   { id: "interchange", label: "Interchange", iconLabel: "GX" },
@@ -465,6 +480,8 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
   const [allResearchTasksLoading, setAllResearchTasksLoading] = useState(false);
   const [validationFindings, setValidationFindings] = useState<ValidationFindingRecord[]>([]);
   const [validationFindingsLoading, setValidationFindingsLoading] = useState(false);
+  const [duplicateCandidates, setDuplicateCandidates] = useState<PersonDuplicateCandidateRecord[]>([]);
+  const [duplicateCandidatesLoading, setDuplicateCandidatesLoading] = useState(false);
   const [familiesByPersonId, setFamiliesByPersonId] = useState<Record<string, FamilyRecord[] | undefined>>(
     {}
   );
@@ -1780,6 +1797,16 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
     }
   }, []);
 
+  const refreshDuplicateCandidates = useCallback(async () => {
+    setDuplicateCandidatesLoading(true);
+    try {
+      const candidates = await getDuplicateCandidates({ status: "PENDING", limit: 100 });
+      setDuplicateCandidates(candidates);
+    } finally {
+      setDuplicateCandidatesLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (activeWorkspace !== "research") {
       return;
@@ -1791,6 +1818,15 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
       setStatus(`Could not load validation findings: ${getErrorMessage(err)}`);
     });
   }, [activeWorkspace, refreshAllResearchTasks, refreshValidationFindings]);
+
+  useEffect(() => {
+    if (activeWorkspace !== "duplicates") {
+      return;
+    }
+    void refreshDuplicateCandidates().catch((err: unknown) => {
+      setStatus(`Could not load duplicate candidates: ${getErrorMessage(err)}`);
+    });
+  }, [activeWorkspace, refreshDuplicateCandidates]);
 
   const handleResearchTaskCreate = useCallback(
     async (body: CreateResearchTaskBody) => {
@@ -1848,6 +1884,38 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
       await refreshValidationFindings();
     },
     [refreshValidationFindings]
+  );
+
+  const handleDuplicateRecompute = useCallback(async () => {
+    const result = await recomputeDuplicateCandidates();
+    setDuplicateCandidates(result.candidates);
+    setStatus(
+      `Duplicate scan complete: ${result.summary.pending} pending candidate(s), ${result.summary.created} new`
+    );
+  }, []);
+
+  const handleDuplicateDismiss = useCallback(
+    async (candidateId: string) => {
+      await updateDuplicateCandidate(candidateId, { status: "DISMISSED" });
+      await refreshDuplicateCandidates();
+    },
+    [refreshDuplicateCandidates]
+  );
+
+  const handleDuplicateMerge = useCallback(
+    async (candidateId: string, canonicalPersonId: string, duplicatePersonId: string) => {
+      const result = await mergeDuplicateCandidate(candidateId, {
+        canonicalPersonId,
+        duplicatePersonId,
+        confirm: true
+      });
+      await refreshGraphData({ bypassSaveGuard: true });
+      await refreshDuplicateCandidates();
+      setSelectedPersonId(result.canonicalPersonId);
+      setGraphCameraFocusPersonId(result.canonicalPersonId);
+      setStatus(`Merged duplicate person into ${result.canonicalPersonId}`);
+    },
+    [refreshDuplicateCandidates, refreshGraphData]
   );
 
   const openPersonFromResearch = useCallback((personId: string) => {
@@ -2236,6 +2304,20 @@ export const PeoplePage = ({ immichBaseUrl = null, currentUserName = null }: Pro
           onTaskUpdate={handleResearchTaskUpdate}
           onTaskDelete={handleResearchTaskDelete}
           onFindingStatusChange={handleValidationFindingStatusChange}
+          onOpenPerson={openPersonFromResearch}
+        />
+      );
+    }
+
+    if (activeWorkspace === "duplicates") {
+      return (
+        <DuplicateReviewWorkspace
+          candidates={duplicateCandidates}
+          loading={duplicateCandidatesLoading}
+          onRefresh={refreshDuplicateCandidates}
+          onRecompute={handleDuplicateRecompute}
+          onDismiss={handleDuplicateDismiss}
+          onMerge={handleDuplicateMerge}
           onOpenPerson={openPersonFromResearch}
         />
       );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5,6 +5,132 @@ body {
   color: #f8fafc;
 }
 
+.report-control-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.report-control-grid label {
+  display: grid;
+  gap: 6px;
+}
+
+.inline-checkbox {
+  display: flex !important;
+  flex-direction: row;
+  gap: 8px !important;
+  align-items: center;
+}
+
+.report-print-frame {
+  color: #0f172a;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.22);
+}
+
+.report-print-frame .hint {
+  color: #475569;
+}
+
+.report-title-page,
+.report-section,
+.report-generation,
+.report-family-block,
+.report-person-card {
+  break-inside: avoid;
+}
+
+.pedigree-report-grid,
+.report-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.report-generation,
+.report-section,
+.report-person-card,
+.report-family-block {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 12px;
+  margin-block: 12px;
+}
+
+.report-person-card h4,
+.report-section h3,
+.report-generation h3 {
+  margin-top: 0;
+}
+
+.report-event-list,
+.report-warning-list {
+  padding-left: 1.25rem;
+}
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.report-table th,
+.report-table td {
+  border: 1px solid #cbd5e1;
+  padding: 8px;
+  text-align: left;
+}
+
+@media print {
+  body {
+    background: #ffffff;
+    color: #0f172a;
+  }
+
+  .workspace-nav,
+  .workspace-resizer,
+  .workspace-context-pane,
+  .print-hidden,
+  .toast-viewport,
+  .skip-link {
+    display: none !important;
+  }
+
+  .app-shell,
+  .people-layout,
+  .workspace-main,
+  .workspace-main-views,
+  .workspace-main-stack {
+    display: block !important;
+    height: auto !important;
+    overflow: visible !important;
+    padding: 0 !important;
+  }
+
+  .workspace-view-hidden {
+    display: none !important;
+  }
+
+  .report-print-frame {
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    width: 100%;
+  }
+
+  .report-title-page {
+    break-after: page;
+  }
+
+  .report-section,
+  .report-generation {
+    break-before: auto;
+  }
+}
+
 #root {
   min-height: 100vh;
   height: 100dvh;

--- a/docs/RELEASE_OPERATIONS.md
+++ b/docs/RELEASE_OPERATIONS.md
@@ -34,10 +34,12 @@
 - Graph layout requests are rejected above the server-side person/relationship caps.
 - Co-occurrence legacy graph responses are capped; clients should use cursor-based edge APIs for large datasets.
 - Full-tree validation scans are capped by `TREEMICH_TREE_VALIDATION_MAX_ROWS` before findings are returned or persisted.
+- Report routes use the expensive-route rate limit plus `TREEMICH_REPORT_MAX_DEPTH` and `TREEMICH_REPORT_MAX_PEOPLE`. They reject over-cap reports instead of silently truncating.
 
 ## Manual Smoke
 
 - After Phase 5 D releases, create two likely duplicate people, run duplicate recompute, dismiss/reopen one candidate, merge into the chosen canonical person, then confirm graph refresh, person detail, family units, research tasks, and duplicate audit behavior still work.
+- For Phase 6 / Phase E reports, create a small tree with grandparents, parents, an adopted child, family event, birth/death events, and a citation. Generate all four reports, toggle living redaction, and use browser print/save-PDF for pedigree and family group sheet.
 - For high-risk merge changes, run or add a live database regression covering relationship, family parent/child, life event, research task, person name, person thumbnail, external identity, validation finding, person media link, and co-occurrence references.
 
 ## Rollback

--- a/docs/RELEASE_OPERATIONS.md
+++ b/docs/RELEASE_OPERATIONS.md
@@ -22,12 +22,15 @@
 - GEDCOM import uses resilient per-entity apply, not one global transaction. A failed job may have already created or updated earlier records; review the route-visible `errorMessage`, `summary`, and capped `lineLog` before retrying.
 - GEDCOM `lineLog` is structured JSON capped by `TREEMICH_GEDCOM_IMPORT_MAX_LINE_LOG`; when entries are omitted the API includes a truncation warning. Do not treat line logs as raw GEDCOM archives: they may still contain names, ids, source titles, or file paths, so avoid forwarding them to third-party systems without PII review.
 - Co-occurrence refreshes should be owned by a single API/worker process in production deployments. If multiple replicas are used, prefer a dedicated worker or leader-election wrapper before increasing scheduled-job volume.
+- Validation findings are recomputed manually through `POST /validation/recompute`; no scheduler or external worker owns this in Phase C. `GET /tree/validation` remains read-only, and `GET /tree/validation?persist=true` is rejected.
+- When `TREEMICH_VALIDATION_ENGINE_ENABLED` is disabled, stored validation findings remain queryable for review, but recompute should be disabled in clients.
 
 ## Capacity Limits
 
 - `TREEMICH_EXPORT_MAX_ROWS` protects synchronous account and GEDCOM export paths from loading very large accounts into memory.
 - Graph layout requests are rejected above the server-side person/relationship caps.
 - Co-occurrence legacy graph responses are capped; clients should use cursor-based edge APIs for large datasets.
+- Full-tree validation scans are capped by `TREEMICH_TREE_VALIDATION_MAX_ROWS` before findings are returned or persisted.
 
 ## Rollback
 

--- a/docs/RELEASE_OPERATIONS.md
+++ b/docs/RELEASE_OPERATIONS.md
@@ -4,6 +4,7 @@
 
 - Run `npm run lint`, `npm run test`, `npm run test:coverage -w @treemich/api`, and `npm run build`.
 - Run `npx prisma migrate deploy --schema apps/api/prisma/schema.prisma` against a throwaway Postgres database before publishing an image.
+- For releases including Phase 5 - D duplicate merge, smoke migration `0029_phase_d_person_duplicates` and verify `PersonDuplicateCandidate` / `PersonMergeAudit` tables exist.
 - Run `npm audit --omit=dev` and review any production dependency findings before release.
 - Verify `WEB_ORIGIN`, `TREEMICH_ENCRYPTION_KEY`, `DATABASE_URL`, `IMMICH_BASE_URL`, and `TREEMICH_TRUST_PROXY` for the target environment.
 
@@ -24,6 +25,8 @@
 - Co-occurrence refreshes should be owned by a single API/worker process in production deployments. If multiple replicas are used, prefer a dedicated worker or leader-election wrapper before increasing scheduled-job volume.
 - Validation findings are recomputed manually through `POST /validation/recompute`; no scheduler or external worker owns this in Phase C. `GET /tree/validation` remains read-only, and `GET /tree/validation?persist=true` is rejected.
 - When `TREEMICH_VALIDATION_ENGINE_ENABLED` is disabled, stored validation findings remain queryable for review, but recompute should be disabled in clients.
+- Duplicate candidates are recomputed manually through `POST /people/duplicates/recompute`; there is no scheduler or background detector. Candidate rows remain persisted until dismissed, merged, or deleted by cascade.
+- Person merge is user-triggered through `POST /people/duplicates/:id/merge` and runs as a single database transaction. It reassigns known Treemich person references, preserves distinct external identities on the canonical person, writes a `PersonMergeAudit` row, and deletes the duplicate profile last. It does not merge Immich faces or people.
 
 ## Capacity Limits
 
@@ -31,6 +34,11 @@
 - Graph layout requests are rejected above the server-side person/relationship caps.
 - Co-occurrence legacy graph responses are capped; clients should use cursor-based edge APIs for large datasets.
 - Full-tree validation scans are capped by `TREEMICH_TREE_VALIDATION_MAX_ROWS` before findings are returned or persisted.
+
+## Manual Smoke
+
+- After Phase 5 D releases, create two likely duplicate people, run duplicate recompute, dismiss/reopen one candidate, merge into the chosen canonical person, then confirm graph refresh, person detail, family units, research tasks, and duplicate audit behavior still work.
+- For high-risk merge changes, run or add a live database regression covering relationship, family parent/child, life event, research task, person name, person thumbnail, external identity, validation finding, person media link, and co-occurrence references.
 
 ## Rollback
 

--- a/docs/genealogy-phases-completion-analysis.md
+++ b/docs/genealogy-phases-completion-analysis.md
@@ -1,6 +1,6 @@
-# Genealogy phases 1–5: completion analysis
+# Genealogy phases 1–5 plus Phase D: completion analysis
 
-This document records **why** the rolled-up plan marks some Phase 1–5 streams as **Partial** (vs **Yes**), what **finishing** them typically involves, and **blockers**. It complements the source plan **“Genealogy feature gap analysis”** (e.g. `genealogy_feature_gap_analysis_0122440a.plan.md` in your Cursor `plans` folder) and the per-phase **Completion status** tables there. Check that plan file for authoritative tables and line-by-line status.
+This document records **why** the rolled-up plan marks some Phase 1–5 and Phase D streams as **Partial** (vs **Yes**), what **finishing** them typically involves, and **blockers**. It complements the source plan **“Genealogy feature gap analysis”** (e.g. `genealogy_feature_gap_analysis_0122440a.plan.md` in your Cursor `plans` folder) and the per-phase **Completion status** tables there. Check that plan file for authoritative tables and line-by-line status.
 
 **How to use:** Treat **Yes** as “shipped for Treemich’s MVP scope.” **Partial** usually means _gap vs a desktop-genealogy ideal_, _optional polish_, _different architecture than the plan’s example_, or _unverified_ behavior—not necessarily that the feature is missing.
 
@@ -8,13 +8,14 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 ## Cross-phase summary
 
-| Phase | Substantive status (plan)        | Partial rows in completion table | Dominant reason for partials                                                          |
-| ----- | -------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
-| **1** | Complete                         | 0                                | NL search can include `PersonName` rows through the saved search preference           |
-| **2** | Complete                         | 1 (Geocoding)                    | Pipelines/flags exist; not “every place auto-filled” by default                       |
-| **3** | Complete                         | 0 (all Yes)                      | Extensions called out only under “Remaining (explicit)”                               |
-| **4** | Complete                         | 0                                | Pedigree-specific graph line styling is implemented                                   |
-| **5** | Complete for Treemich GEDCOM MVP | Several                          | Bar set at Gramps-class toolchain + infra (workers, full CI, storage/error artifacts) |
+| Phase | Substantive status (plan)                            | Partial rows in completion table | Dominant reason for partials                                                          |
+| ----- | ---------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
+| **1** | Complete                                             | 0                                | NL search can include `PersonName` rows through the saved search preference           |
+| **2** | Complete                                             | 1 (Geocoding)                    | Pipelines/flags exist; not “every place auto-filled” by default                       |
+| **3** | Complete                                             | 0 (all Yes)                      | Extensions called out only under “Remaining (explicit)”                               |
+| **4** | Complete                                             | 0                                | Pedigree-specific graph line styling is implemented                                   |
+| **5** | Complete for Treemich GEDCOM MVP                     | Several                          | Bar set at Gramps-class toolchain + infra (workers, full CI, storage/error artifacts) |
+| **D** | Complete for focused Treemich duplicate review/merge | Several verification gaps        | Core queue/API/UI/merge/audit shipped; live DB regression and manual smoke remain     |
 
 ---
 
@@ -22,7 +23,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 **Plan exit:** Event types and `customLabel` round-trip; alternate names editable; validation surfaces real issues on bad synthetic data.
 
-### Completion table: partials
+### Phase 1 completion table: partials
 
 | Stream                              | Met?    | Why partial (if applicable)                                                                                                             | Effort to close | Blockers |
 | ----------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------- | -------- |
@@ -44,7 +45,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 **Plan exit:** Tasks CRUD stable; timeline shows event types; map acceptable at ~500 pins (plan suggests a load-test harness; not required to be checked in).
 
-### Completion table: partials
+### Phase 2 completion table: partials
 
 | Stream         | Met?        | Why partial (if applicable)                                                                                                  | Effort to close                                                  | Blockers                                   |
 | -------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------ |
@@ -65,14 +66,14 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 **Plan exit:** Shared sources, citations on life events, media openable; migration path from older citation shape (already consolidated in schema).
 
-### Completion table: partials
+### Phase 3 completion table: partials
 
 **None** — all streams **Yes**.
 
-### Remaining (explicit)
+### Phase 3 remaining (explicit)
 
 - **`MediaLinkTargetType` for `Family`**: shipped in Phase C with target validation, family UI attach/unlink, and GEDCOM FAM-root OBJE import/export alignment.
-- **Deduplication UX** beyond merge-sources API: medium.
+- **Source deduplication UX** beyond merge-sources API: medium. Person duplicate review/merge shipped in Phase D.
 - **Signed URLs / object storage** hardening for large evidence files: medium–high (infra, security, cost).
 
 ---
@@ -81,14 +82,14 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 **Plan exit:** Manual spot-checks; Phase 5a emits **FAM** in GEDCOM (see Phase 5 / writer).
 
-### Completion table: partials
+### Phase 4 completion table: partials
 
 | Stream                                                                    | Met?    | Why partial (if applicable)                                                                                            | Effort to close | Blockers |
 | ------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------- | --------------- | -------- |
 | ADR 0001, schema, migration, life events, API, UI, NL, account `families` | Yes     | —                                                                                                                      | —               | —        |
 | **Graph**                                                                 | **Yes** | Layout uses parent/child edges and pedigree-specific parent-edge styling is implemented for non-biological child links | —               | —        |
 
-### Remaining (explicit)
+### Phase 4 remaining (explicit)
 
 - Optional **dry-run / preview UI** for Phase 4 **backfill** (CLI + logs today): medium.
 - **`Family.externalIds.gedcomFam`**: plan marks **done** (migration 0020); behavior tied to GEDCOM in Phase 5.
@@ -101,7 +102,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 **Product constraint:** People are Treemich-owned identities. GEDCOM import can create Treemich people with `unmatchedIndiPolicy: "CREATE"`; creating people inside Immich remains out of scope.
 
-### Completion table: partials (high level)
+### Phase 5 completion table: partials (high level)
 
 | Stream                                        | Met?                            | Why partial                                                                                                                                                              | Effort to close                                       | Blockers                                |
 | --------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- | --------------------------------------- |
@@ -128,6 +129,32 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 ---
 
+## Phase D — Duplicate candidates and guarded merge
+
+**Plan exit:** User-reviewed duplicate candidate queue; merge requires explicit confirmation; Treemich-owned person references move to the canonical person in one DB transaction; external identities are preserved; audit entries record merge outcome.
+
+### Phase D completion table: partials (high level)
+
+| Stream                   | Met?          | Why partial                                                                                                                                                                                                                                                                        | Effort to close                                     | Blockers                          |
+| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | --------------------------------- |
+| Candidate schema + audit | Yes           | `PersonDuplicateCandidate`, `PersonDuplicateCandidateStatus`, and `PersonMergeAudit` shipped in migration `0029_phase_d_person_duplicates`                                                                                                                                         | —                                                   | —                                 |
+| Shared contracts         | Yes           | `packages/shared/src/personDuplicates.ts` has list, patch, merge, reason, recompute, and result types/schemas                                                                                                                                                                      | —                                                   | —                                 |
+| Detection API            | Yes / Partial | `POST /people/duplicates/recompute` scores normalized names, surname/given initial, birth/death dates, close family graph overlap, and co-occurrence support; broad fuzzy matching/tuning remains future polish                                                                    | Low–medium: add corpus/tuning data                  | Product scoring judgment          |
+| Review API               | Yes           | `GET /people/duplicates`, `PATCH /people/duplicates/:id`, and persisted dismissed state exist                                                                                                                                                                                      | —                                                   | —                                 |
+| Merge engine             | Yes / Partial | Guarded transaction moves known person FKs/pseudo-FKs, dedupes relationship/family child/person media/co-occurrence collisions, preserves external identities, writes `PersonMergeAudit`, then deletes the duplicate profile. Live DB FK regression suite still needs to be added. | Medium: add throwaway DB regression seed/assertions | Test DB setup, collision fixtures |
+| Web workspace            | Yes / Partial | `DuplicateReviewWorkspace` is mounted as active Duplicates workspace with recompute, refresh, open-person actions, dismiss, canonical selection, and merge confirmation. Page-level integration smoke remains optional hardening.                                                  | Low: add page integration smoke                     | UI test fixture breadth           |
+| Verification             | Partial       | Focused shared/API/web tests, lint, Prettier, Prisma format/generate passed. Throwaway migration smoke, live DB merge regression, and manual UI smoke remain.                                                                                                                      | Low–medium                                          | Test database/runtime             |
+
+### Phase D remaining (explicit)
+
+- Add a live DB `person-merge` regression suite covering every person reference surface and collision case.
+- Run `npx prisma migrate deploy --schema apps/api/prisma/schema.prisma` against a throwaway database that includes migration `0029_phase_d_person_duplicates`.
+- Manual smoke: create likely duplicate people, recompute, dismiss/reopen, merge into canonical, verify graph/person details/families/research still load.
+- Broader duplicate scoring corpus/tuning for large real-world trees.
+- Immich-native face merge remains out of scope; Treemich preserves distinct Immich external identities on the canonical person.
+
+---
+
 ## Tracking
 
 | Follow-up                                | Suggested owner      | Suggested signal                            |
@@ -137,6 +164,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 | Media on `Family` (Phase 3)              | Product + full-stack | ADR + schema                                |
 | Graph pedigree styling (Phase 4)         | Frontend             | Implemented; keep regression tests          |
 | GEDCOM partials (Phase 5)                | Platform + product   | Roadmap; Immich contact for people creation |
+| Duplicate merge hardening (Phase D)      | Platform + QA        | Add live DB FK regression and manual smoke  |
 
 ---
 

--- a/docs/genealogy-phases-completion-analysis.md
+++ b/docs/genealogy-phases-completion-analysis.md
@@ -35,7 +35,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 ### Remaining (explicit) — not all in table
 
 - **Broader GEDCOM event vocabulary** than current enum: medium–high (enum growth + migrations) or high (string GEDCOM tags + rules).
-- **Persisted** `ValidationFinding` + optional **nightly** job: medium (schema, invalidation, scheduler).
+- **Persisted** `ValidationFinding`: shipped in Phase C as manual `POST /validation/recompute`; optional scheduler remains future ops work.
 - Richer **event-type taxonomy / icons**: low–medium (UX).
 
 ---
@@ -55,7 +55,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 ### Remaining (explicit)
 
-- **Global** research-task hub page: medium (new UI surface).
+- **Global** research-task hub page: shipped in Phase C as the Research workspace, combining active tasks and persisted validation issues.
 - Formal **~500 pin** load test artifact: low–medium.
 - Stronger **living-person map redaction** policy: medium; **legal/product** as much as code.
 
@@ -71,7 +71,7 @@ This document records **why** the rolled-up plan marks some Phase 1–5 streams 
 
 ### Remaining (explicit)
 
-- **`MediaLinkTargetType` for `Family`** (or other subjects): medium — schema, UI, GEDCOM alignment (overlaps Phase 5).
+- **`MediaLinkTargetType` for `Family`**: shipped in Phase C with target validation, family UI attach/unlink, and GEDCOM FAM-root OBJE import/export alignment.
 - **Deduplication UX** beyond merge-sources API: medium.
 - **Signed URLs / object storage** hardening for large evidence files: medium–high (infra, security, cost).
 

--- a/docs/person-migration-runbook.md
+++ b/docs/person-migration-runbook.md
@@ -70,6 +70,8 @@ Run these checks after deploy.
 select count(*) as people from "PersonProfile";
 select "provider", count(*) from "PersonExternalIdentity" group by "provider" order by "provider";
 select count(*) as thumbnails from "PersonThumbnail";
+select count(*) as duplicate_candidates from "PersonDuplicateCandidate";
+select count(*) as merge_audits from "PersonMergeAudit";
 ```
 
 ```sql
@@ -113,6 +115,21 @@ left join "PersonProfile" b on b."id" = e."personBId" and b."userId" = e."userId
 where a."id" is null or b."id" is null;
 ```
 
+```sql
+select count(*) as broken_duplicate_candidate_refs
+from "PersonDuplicateCandidate" c
+left join "PersonProfile" a on a."id" = c."personAId" and a."userId" = c."userId"
+left join "PersonProfile" b on b."id" = c."personBId" and b."userId" = c."userId"
+where a."id" is null or b."id" is null;
+```
+
+```sql
+select count(*) as broken_merge_audit_canonical_refs
+from "PersonMergeAudit" a
+left join "PersonProfile" p on p."id" = a."canonicalPersonId" and p."userId" = a."userId"
+where p."id" is null;
+```
+
 Expected result for all `broken_*` checks is `0`.
 
 ## Smoke Tests
@@ -122,6 +139,7 @@ Verify these user-facing paths:
 - Sign in with Treemich email/password on a fresh or existing install.
 - Create a standalone person without linking Immich.
 - Create/edit a parent-child or spouse relationship.
+- Create two likely duplicate people, recompute duplicate candidates from the Duplicates workspace, dismiss/reopen a candidate, then merge into the intended canonical person and verify the duplicate profile disappears.
 - Export account data with `GET /api/export/account?format=zip` and confirm `account.json`, `manifest.json`, and any available `thumbnails/...` files exist.
 - Export GEDCOM and parse it with a GEDCOM reader or re-import preview.
 - If Immich is configured, link Immich, load provider preview, import one thumbnail, then unlink Immich. Imported thumbnail/co-occurrence data should remain visible, but refresh/import should stop until relinked.

--- a/packages/shared/src/evidence.ts
+++ b/packages/shared/src/evidence.ts
@@ -63,12 +63,17 @@ export const patchMediaObjectBodySchema = z.object({
   title: z.string().optional().nullable()
 });
 
-export const mediaLinkTargetTypeSchema = z.enum(["PERSON_PROFILE", "LIFE_EVENT", "SOURCE"]);
+export const mediaLinkTargetTypeSchema = z.enum(["PERSON_PROFILE", "LIFE_EVENT", "SOURCE", "FAMILY"]);
 
 export const createMediaLinkBodySchema = z.object({
   targetType: mediaLinkTargetTypeSchema,
   targetId: z.string().min(1),
   notes: z.string().optional().nullable()
+});
+
+export const targetMediaLinkQuerySchema = z.object({
+  targetType: mediaLinkTargetTypeSchema,
+  targetId: z.string().min(1)
 });
 
 export type CreateRepositoryBody = z.infer<typeof createRepositoryBodySchema>;
@@ -80,6 +85,8 @@ export type MergeSourcesBody = z.infer<typeof mergeSourcesBodySchema>;
 export type CreateMediaObjectBody = z.infer<typeof createMediaObjectBodySchema>;
 export type PatchMediaObjectBody = z.infer<typeof patchMediaObjectBodySchema>;
 export type CreateMediaLinkBody = z.infer<typeof createMediaLinkBodySchema>;
+export type MediaLinkTargetType = z.infer<typeof mediaLinkTargetTypeSchema>;
+export type TargetMediaLinkQuery = z.infer<typeof targetMediaLinkQuerySchema>;
 
 export type RepositoryRecord = {
   id: string;
@@ -118,8 +125,12 @@ export type MediaObjectRecord = {
 export type MediaLinkRecord = {
   id: string;
   mediaObjectId: string;
-  targetType: z.infer<typeof mediaLinkTargetTypeSchema>;
+  targetType: MediaLinkTargetType;
   targetId: string;
   notes: string | null;
   createdAt: string;
+};
+
+export type TargetMediaLinkRecord = MediaLinkRecord & {
+  mediaObject: MediaObjectRecord;
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -169,6 +169,7 @@ export * from "./lifeEvents.js";
 export * from "./personNames.js";
 export * from "./researchTasks.js";
 export * from "./evidence.js";
+export * from "./validationFindings.js";
 
 /** Weighted edge between two people derived from shared photo appearances. */
 export type PhotoCooccurrenceEdge = {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -167,6 +167,7 @@ export type RelationshipRecord = {
 export * from "./families.js";
 export * from "./lifeEvents.js";
 export * from "./personNames.js";
+export * from "./personDuplicates.js";
 export * from "./researchTasks.js";
 export * from "./evidence.js";
 export * from "./validationFindings.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -171,6 +171,7 @@ export * from "./personDuplicates.js";
 export * from "./researchTasks.js";
 export * from "./evidence.js";
 export * from "./validationFindings.js";
+export * from "./reports.js";
 
 /** Weighted edge between two people derived from shared photo appearances. */
 export type PhotoCooccurrenceEdge = {

--- a/packages/shared/src/personDuplicates.ts
+++ b/packages/shared/src/personDuplicates.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const personDuplicateCandidateStatusValues = ["PENDING", "DISMISSED", "MERGED"] as const;
+export type PersonDuplicateCandidateStatus = (typeof personDuplicateCandidateStatusValues)[number];
+export const personDuplicateCandidateStatusSchema = z.enum(personDuplicateCandidateStatusValues);
+
+export const personDuplicateReasonCodeValues = [
+  "name",
+  "vital",
+  "family",
+  "cooccurrence",
+  "externalIdentity",
+  "review"
+] as const;
+export type PersonDuplicateReasonCode = (typeof personDuplicateReasonCodeValues)[number];
+export const personDuplicateReasonCodeSchema = z.enum(personDuplicateReasonCodeValues);
+
+export const personDuplicateReasonSchema = z.object({
+  code: personDuplicateReasonCodeSchema,
+  label: z.string().min(1),
+  detail: z.string().min(1).optional(),
+  weight: z.number().min(0)
+});
+
+export const personDuplicateListQuerySchema = z.object({
+  status: personDuplicateCandidateStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional()
+});
+
+export const patchPersonDuplicateCandidateBodySchema = z.object({
+  status: z.enum(["PENDING", "DISMISSED"])
+});
+
+export const mergePeopleBodySchema = z
+  .object({
+    canonicalPersonId: z.string().trim().min(1),
+    duplicatePersonId: z.string().trim().min(1),
+    confirm: z.literal(true)
+  })
+  .refine((body) => body.canonicalPersonId !== body.duplicatePersonId, {
+    message: "canonicalPersonId and duplicatePersonId must differ",
+    path: ["duplicatePersonId"]
+  });
+
+export type PersonDuplicateReason = z.infer<typeof personDuplicateReasonSchema>;
+export type PersonDuplicateListQuery = z.infer<typeof personDuplicateListQuerySchema>;
+export type PatchPersonDuplicateCandidateBody = z.infer<typeof patchPersonDuplicateCandidateBodySchema>;
+export type MergePeopleBody = z.infer<typeof mergePeopleBodySchema>;
+
+export type PersonDuplicateSummary = {
+  id: string;
+  label: string;
+  givenName: string | null;
+  surname: string | null;
+  birthDate: string | null;
+  deathDate: string | null;
+  externalIdentityCount: number;
+};
+
+export type PersonDuplicateCandidateRecord = {
+  id: string;
+  personAId: string;
+  personBId: string;
+  score: number;
+  reasons: PersonDuplicateReason[];
+  status: PersonDuplicateCandidateStatus;
+  dismissedAt: string | null;
+  mergedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  personA: PersonDuplicateSummary;
+  personB: PersonDuplicateSummary;
+};
+
+export type PersonDuplicateRecomputeResponse = {
+  candidates: PersonDuplicateCandidateRecord[];
+  summary: {
+    created: number;
+    updated: number;
+    preservedDismissed: number;
+    pending: number;
+  };
+};
+
+export type PersonMergeResult = {
+  candidate: PersonDuplicateCandidateRecord;
+  auditId: string;
+  canonicalPersonId: string;
+  duplicatePersonId: string;
+  changedCounts: Record<string, number>;
+  warnings: string[];
+};

--- a/packages/shared/src/reports.ts
+++ b/packages/shared/src/reports.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+import { dateQualifierSchema, lifeEventTypeSchema } from "./lifeEvents.js";
+import { familyChildPedigreeSchema } from "./families.js";
+
+const reportGenderSchema = z.enum(["MALE", "FEMALE", "OTHER", "UNKNOWN"]);
+
+export const reportTypeValues = ["pedigree", "descendants", "family-group", "register"] as const;
+export type ReportType = (typeof reportTypeValues)[number];
+
+export const reportWarningSchema = z.object({
+  code: z.string().min(1),
+  message: z.string().min(1),
+  personId: z.string().min(1).optional(),
+  familyId: z.string().min(1).optional()
+});
+export type ReportWarning = z.infer<typeof reportWarningSchema>;
+
+export const reportCitationSummarySchema = z.object({
+  id: z.string().min(1),
+  sourceTitle: z.string().min(1),
+  repositoryName: z.string().nullable(),
+  page: z.string().nullable(),
+  notes: z.string().nullable()
+});
+export type ReportCitationSummary = z.infer<typeof reportCitationSummarySchema>;
+
+export const reportLifeEventSummarySchema = z.object({
+  id: z.string().min(1),
+  type: lifeEventTypeSchema,
+  label: z.string().min(1),
+  dateQualifier: dateQualifierSchema,
+  year: z.number().int().nullable(),
+  month: z.number().int().nullable(),
+  day: z.number().int().nullable(),
+  endYear: z.number().int().nullable(),
+  endMonth: z.number().int().nullable(),
+  endDay: z.number().int().nullable(),
+  dateDisplay: z.string().nullable(),
+  placeDisplay: z.string().nullable(),
+  notes: z.string().nullable(),
+  citations: z.array(reportCitationSummarySchema)
+});
+export type ReportLifeEventSummary = z.infer<typeof reportLifeEventSummarySchema>;
+
+export const reportPersonSummarySchema = z.object({
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  gender: reportGenderSchema,
+  primaryName: z.string().nullable(),
+  alternateNames: z.array(z.string()),
+  isLiving: z.boolean(),
+  isRedacted: z.boolean(),
+  events: z.array(reportLifeEventSummarySchema)
+});
+export type ReportPersonSummary = z.infer<typeof reportPersonSummarySchema>;
+
+export const reportBaseParametersSchema = z.object({
+  redactLiving: z.boolean().default(false)
+});
+
+export const depthReportParametersSchema = reportBaseParametersSchema.extend({
+  rootPersonId: z.string().min(1),
+  depth: z.number().int().min(1)
+});
+
+export const pedigreeReportRequestSchema = depthReportParametersSchema;
+export type PedigreeReportRequest = z.infer<typeof pedigreeReportRequestSchema>;
+
+export const descendantReportRequestSchema = depthReportParametersSchema;
+export type DescendantReportRequest = z.infer<typeof descendantReportRequestSchema>;
+
+export const registerReportRequestSchema = depthReportParametersSchema;
+export type RegisterReportRequest = z.infer<typeof registerReportRequestSchema>;
+
+export const familyGroupSheetRequestSchema = reportBaseParametersSchema.extend({
+  familyId: z.string().min(1)
+});
+export type FamilyGroupSheetRequest = z.infer<typeof familyGroupSheetRequestSchema>;
+
+const reportMetadataSchema = z.object({
+  generatedAt: z.string().datetime(),
+  warnings: z.array(reportWarningSchema)
+});
+
+export const pedigreeEdgeSchema = z.object({
+  childPersonId: z.string().min(1),
+  parentPersonId: z.string().min(1),
+  familyId: z.string().min(1).nullable()
+});
+export type PedigreeEdge = z.infer<typeof pedigreeEdgeSchema>;
+
+export const pedigreeReportResponseSchema = reportMetadataSchema.extend({
+  type: z.literal("pedigree"),
+  parameters: pedigreeReportRequestSchema,
+  root: reportPersonSummarySchema,
+  generations: z.array(
+    z.object({
+      generation: z.number().int().min(0),
+      people: z.array(reportPersonSummarySchema)
+    })
+  ),
+  edges: z.array(pedigreeEdgeSchema)
+});
+export type PedigreeReportResponse = z.infer<typeof pedigreeReportResponseSchema>;
+
+export const descendantFamilyGroupSchema = z.object({
+  familyId: z.string().min(1).nullable(),
+  parents: z.array(reportPersonSummarySchema),
+  children: z.array(
+    z.object({
+      person: reportPersonSummarySchema,
+      pedigree: familyChildPedigreeSchema.nullable()
+    })
+  )
+});
+export type DescendantFamilyGroup = z.infer<typeof descendantFamilyGroupSchema>;
+
+export const descendantReportResponseSchema = reportMetadataSchema.extend({
+  type: z.literal("descendants"),
+  parameters: descendantReportRequestSchema,
+  root: reportPersonSummarySchema,
+  generations: z.array(
+    z.object({
+      generation: z.number().int().min(0),
+      families: z.array(descendantFamilyGroupSchema)
+    })
+  )
+});
+export type DescendantReportResponse = z.infer<typeof descendantReportResponseSchema>;
+
+export const familyGroupSheetResponseSchema = reportMetadataSchema.extend({
+  type: z.literal("family-group"),
+  parameters: familyGroupSheetRequestSchema,
+  family: z.object({
+    id: z.string().min(1),
+    notes: z.string().nullable(),
+    parents: z.array(reportPersonSummarySchema),
+    children: z.array(
+      z.object({
+        person: reportPersonSummarySchema,
+        pedigree: familyChildPedigreeSchema.nullable()
+      })
+    ),
+    events: z.array(reportLifeEventSummarySchema),
+    citations: z.array(reportCitationSummarySchema)
+  })
+});
+export type FamilyGroupSheetResponse = z.infer<typeof familyGroupSheetResponseSchema>;
+
+export const registerNarrativeSectionSchema = z.object({
+  number: z.number().int().min(1),
+  generation: z.number().int().min(0),
+  person: reportPersonSummarySchema,
+  familySummaries: z.array(z.string()),
+  prose: z.array(z.string()),
+  citations: z.array(reportCitationSummarySchema)
+});
+export type RegisterNarrativeSection = z.infer<typeof registerNarrativeSectionSchema>;
+
+export const registerReportResponseSchema = reportMetadataSchema.extend({
+  type: z.literal("register"),
+  parameters: registerReportRequestSchema,
+  root: reportPersonSummarySchema,
+  sections: z.array(registerNarrativeSectionSchema)
+});
+export type RegisterReportResponse = z.infer<typeof registerReportResponseSchema>;
+
+export const reportResponseSchema = z.discriminatedUnion("type", [
+  pedigreeReportResponseSchema,
+  descendantReportResponseSchema,
+  familyGroupSheetResponseSchema,
+  registerReportResponseSchema
+]);
+export type ReportResponse = z.infer<typeof reportResponseSchema>;

--- a/packages/shared/src/validationFindings.ts
+++ b/packages/shared/src/validationFindings.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const validationFindingStatusValues = ["OPEN", "IN_PROGRESS", "RESOLVED", "DISMISSED"] as const;
+export type ValidationFindingStatus = (typeof validationFindingStatusValues)[number];
+export const validationFindingStatusSchema = z.enum(validationFindingStatusValues);
+
+export const validationFindingSeverityValues = ["error", "warning"] as const;
+export type ValidationFindingSeverity = (typeof validationFindingSeverityValues)[number];
+export const validationFindingSeveritySchema = z.enum(validationFindingSeverityValues);
+
+export const validationFindingListQuerySchema = z.object({
+  status: z.union([validationFindingStatusSchema, z.array(validationFindingStatusSchema)]).optional(),
+  severity: validationFindingSeveritySchema.optional(),
+  code: z.string().trim().min(1).optional(),
+  personId: z.string().trim().min(1).optional(),
+  familyId: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional()
+});
+
+export const patchValidationFindingBodySchema = z.object({
+  status: z.enum(["OPEN", "IN_PROGRESS", "DISMISSED"])
+});
+
+export type ValidationFindingListQuery = z.infer<typeof validationFindingListQuerySchema>;
+export type PatchValidationFindingBody = z.infer<typeof patchValidationFindingBodySchema>;
+
+export type ValidationFindingDisplayContext = {
+  person?: { id: string; label: string } | null;
+  relatedPerson?: { id: string; label: string } | null;
+  relationship?: {
+    id: string;
+    label: string;
+    fromPersonId: string;
+    toPersonId: string;
+  } | null;
+  family?: { id: string; label: string } | null;
+};
+
+export type ValidationFindingRecord = {
+  id: string;
+  code: string;
+  severity: ValidationFindingSeverity;
+  message: string;
+  personId: string | null;
+  relationshipId: string | null;
+  relatedPersonId: string | null;
+  familyId: string | null;
+  status: ValidationFindingStatus;
+  fingerprint: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  resolvedAt: string | null;
+  dismissedAt: string | null;
+  inProgressAt: string | null;
+  metadata: Record<string, unknown>;
+  display: ValidationFindingDisplayContext;
+};
+
+export type ValidationRecomputeSummary = {
+  current: number;
+  created: number;
+  reopened: number;
+  resolved: number;
+  inProgressStillPresent: number;
+  dismissedStillPresent: number;
+};

--- a/packages/shared/test/evidence.spec.ts
+++ b/packages/shared/test/evidence.spec.ts
@@ -83,5 +83,12 @@ describe("evidence Zod schemas", () => {
         notes: null
       })
     ).toEqual({ targetType: "SOURCE", targetId: "src-1", notes: null });
+    expect(
+      createMediaLinkBodySchema.parse({
+        targetType: "FAMILY",
+        targetId: "fam-1",
+        notes: null
+      })
+    ).toEqual({ targetType: "FAMILY", targetId: "fam-1", notes: null });
   });
 });

--- a/packages/shared/test/personDuplicates.spec.ts
+++ b/packages/shared/test/personDuplicates.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergePeopleBodySchema,
+  patchPersonDuplicateCandidateBodySchema,
+  personDuplicateListQuerySchema,
+  personDuplicateReasonSchema
+} from "../src/personDuplicates.js";
+
+describe("person duplicate contracts", () => {
+  it("parses duplicate list filters with numeric coercion", () => {
+    expect(personDuplicateListQuerySchema.parse({ status: "PENDING", limit: "25", offset: "5" })).toEqual({
+      status: "PENDING",
+      limit: 25,
+      offset: 5
+    });
+  });
+
+  it("accepts review status updates only for pending/dismissed", () => {
+    expect(patchPersonDuplicateCandidateBodySchema.parse({ status: "DISMISSED" })).toEqual({
+      status: "DISMISSED"
+    });
+    expect(patchPersonDuplicateCandidateBodySchema.safeParse({ status: "MERGED" }).success).toBe(false);
+  });
+
+  it("requires explicit confirmation and two different people for merge", () => {
+    expect(
+      mergePeopleBodySchema.parse({
+        canonicalPersonId: "p1",
+        duplicatePersonId: "p2",
+        confirm: true
+      })
+    ).toEqual({
+      canonicalPersonId: "p1",
+      duplicatePersonId: "p2",
+      confirm: true
+    });
+    expect(
+      mergePeopleBodySchema.safeParse({
+        canonicalPersonId: "p1",
+        duplicatePersonId: "p1",
+        confirm: true
+      }).success
+    ).toBe(false);
+    expect(
+      mergePeopleBodySchema.safeParse({
+        canonicalPersonId: "p1",
+        duplicatePersonId: "p2",
+        confirm: false
+      }).success
+    ).toBe(false);
+  });
+
+  it("parses weighted reason rows", () => {
+    expect(
+      personDuplicateReasonSchema.parse({
+        code: "name",
+        label: "Same full name",
+        detail: "alex smith",
+        weight: 45
+      })
+    ).toEqual({
+      code: "name",
+      label: "Same full name",
+      detail: "alex smith",
+      weight: 45
+    });
+  });
+});

--- a/packages/shared/test/reports.spec.ts
+++ b/packages/shared/test/reports.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  descendantReportRequestSchema,
+  familyGroupSheetResponseSchema,
+  pedigreeReportRequestSchema,
+  reportPersonSummarySchema
+} from "../src/reports.js";
+
+describe("report contracts", () => {
+  it("parses depth requests and defaults redactLiving off", () => {
+    expect(pedigreeReportRequestSchema.parse({ rootPersonId: "p1", depth: 4 })).toEqual({
+      rootPersonId: "p1",
+      depth: 4,
+      redactLiving: false
+    });
+    expect(() => descendantReportRequestSchema.parse({ rootPersonId: "p1", depth: 0 })).toThrow();
+  });
+
+  it("requires explicit redaction state on person summaries", () => {
+    const person = reportPersonSummarySchema.parse({
+      id: "p1",
+      displayName: "Living person",
+      gender: "UNKNOWN",
+      primaryName: null,
+      alternateNames: [],
+      isLiving: true,
+      isRedacted: true,
+      events: []
+    });
+    expect(person.isRedacted).toBe(true);
+  });
+
+  it("parses family group sheet report metadata", () => {
+    const parsed = familyGroupSheetResponseSchema.parse({
+      type: "family-group",
+      generatedAt: "2026-04-29T00:00:00.000Z",
+      parameters: { familyId: "fam1", redactLiving: false },
+      warnings: [],
+      family: {
+        id: "fam1",
+        notes: null,
+        parents: [],
+        children: [],
+        events: [],
+        citations: []
+      }
+    });
+    expect(parsed.family.id).toBe("fam1");
+  });
+});


### PR DESCRIPTION
### Phase 6 — Printable reports and PDFs

**Goals:** Static outputs for printing and sharing files (distinct from interactive 3D graph).

**Workstreams**

| Stream | Actions |
|--------|---------|
| **Pedigree / descendant charts** | **Done for browser-print v1** — structured JSON routes + static HTML report views + print CSS. |
| **PDF** | **Partial by design** — browser print/save-PDF is shipped; server-side Chromium/pdf-lib jobs remain deferred behind `TREEMICH_REPORT_PDF_ENABLED`. |
| **Family group sheet** | **Done for browser-print v1** — uses `Family` / `FamilyChild`, family events, parent/child events, citations, and pedigree labels. |
| **Narrative / register** | **Done for browser-print v1** — deterministic template prose; no LLM generation. |

**Rollout:** Report routes behind **`TREEMICH_REPORTS_ENABLED`** (default on). Depth and person caps use **`TREEMICH_REPORT_MAX_DEPTH`** and **`TREEMICH_REPORT_MAX_PEOPLE`**. Server PDF/export jobs are explicitly deferred; no report cache tables were added for v1.

**Exit criteria:** Browser print/save-PDF works for A4/Letter reports; charts are legible at configured default depth; backend enforces living redaction and depth/person caps.

**Completion status (treemich repo):** Phase 6 is **implemented for browser-print v1**.

| Stream | Met? | Notes |
|--------|------|-------|
| Shared contracts | **Yes** | [`packages/shared/src/reports.ts`](g:\Development\treemich\packages\shared\src\reports.ts), exported from [`packages/shared/src/index.ts`](g:\Development\treemich\packages\shared\src\index.ts), with [`packages/shared/test/reports.spec.ts`](g:\Development\treemich\packages\shared\test\reports.spec.ts). |
| Report service / routes | **Yes** | [`apps/api/src/reports/reportDataService.ts`](g:\Development\treemich\apps\api\src\reports\reportDataService.ts), [`apps/api/src/routes/reports.ts`](g:\Development\treemich\apps\api\src\routes\reports.ts), and service/app registration. Routes cover pedigree, descendants, family group sheet, and register/narrative. |
| Limits / redaction | **Yes** | `TREEMICH_REPORTS_ENABLED`, `TREEMICH_REPORT_MAX_DEPTH`, `TREEMICH_REPORT_MAX_PEOPLE`, and `TREEMICH_REPORT_PDF_ENABLED` are in [`env.ts`](g:\Development\treemich\apps\api\src\config\env.ts). Living redaction uses no-`DEATH` heuristic and suppresses detailed private fields for redacted people. |
| Web reports workspace | **Yes** | [`ReportsWorkspace`](g:\Development\treemich\apps\web\src\components\reports\ReportsWorkspace.tsx) is active from [`people.tsx`](g:\Development\treemich\apps\web\src\pages\people.tsx), with root/family/depth/redaction controls and browser print/save-PDF. |
| Print CSS | **Yes** | Report print rules live in [`apps/web/src/styles.css`](g:\Development\treemich\apps\web\src\styles.css). |
| Tests | **Yes** | Shared schema tests, API report route/redaction tests, web client/component tests, and People page integration coverage were added. |
| Server PDF jobs | **Deferred** | Not required for v1; browser print/save-PDF is accepted Phase 6 completion target. |

**Completed verification:** `npm run lint -w @treemich/shared`; `npm run build -w @treemich/shared && npm run lint -w @treemich/api`; `npm run build -w @treemich/shared && npm run lint -w @treemich/web`; `npm run test -w @treemich/shared -- reports`; `npm run test -w @treemich/api -- reports`; `npm run test -w @treemich/web -- ReportsWorkspace api.spec`; `npm run test -w @treemich/web -- people-page.integration.spec.tsx`.

**Remaining:** manual browser print/save-PDF smoke on a representative tree, optional screenshot/PDF visual regression, server-side PDF/export jobs if product later needs them, and additional report types beyond the four v1 reports.

---