### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,38 @@
 
 - Always add tests (unit, e2e, integration) for any new feature, bug fix or regression.
 - When tests fail, fix the underlying code — never comment out tests, skip them, or change assertions to make them pass.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | How to run | Port |
+|---------|-----------|------|
+| PostgreSQL 16 | `docker compose up -d postgres` | 54321 (host) → 5432 |
+| API (Fastify + Prisma) | `npm run dev:api` or `npm run dev` | 4000 |
+| Web (Vite + React) | `npm run dev:web` or `npm run dev` | 5173 |
+
+### Quick start (after update script has run)
+
+1. Ensure Docker daemon is running: `dockerd &>/var/log/dockerd.log &` (wait ~5s)
+2. `docker compose up -d postgres` — start PostgreSQL
+3. `npx prisma migrate deploy --schema apps/api/prisma/schema.prisma` — apply any new migrations
+4. `npm run dev` — starts both API (:4000) and Web (:5173) concurrently
+
+### Key development commands
+
+See `README.md` "Development Commands" section. Summary:
+- `npm run lint` — ESLint + Prettier + TypeScript type-check (all workspaces)
+- `npm run test` — Vitest across shared/api/web packages
+- `npm run build` — production build (shared → api → web)
+- `npm run dev` — concurrent API + Web dev servers
+
+### Non-obvious caveats
+
+- The **first login** with a new email/password auto-creates the Treemich account (no separate signup endpoint).
+- `npm run lint` builds `@treemich/shared` first (needed for type-checking downstream packages).
+- `npm run test` also builds `@treemich/shared` first before running tests.
+- Prisma client must be generated after `npm install` before the API can start: `npm run prisma:generate -w @treemich/api`.
+- Docker in this VM requires `fuse-overlayfs` storage driver and `iptables-legacy` (not nftables). Ensure these are set before starting `dockerd`.
+- The `.env` file needs `TREEMICH_ENCRYPTION_KEY` set to a 64-char hex string (`openssl rand -hex 32`). Without it the API will crash on startup.
+- Immich integration is entirely optional. The app works standalone with email/password auth and manual person creation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,11 @@
 
 ### Services overview
 
-| Service | How to run | Port |
-|---------|-----------|------|
-| PostgreSQL 16 | `docker compose up -d postgres` | 54321 (host) → 5432 |
-| API (Fastify + Prisma) | `npm run dev:api` or `npm run dev` | 4000 |
-| Web (Vite + React) | `npm run dev:web` or `npm run dev` | 5173 |
+| Service                | How to run                         | Port                |
+| ---------------------- | ---------------------------------- | ------------------- |
+| PostgreSQL 16          | `docker compose up -d postgres`    | 54321 (host) → 5432 |
+| API (Fastify + Prisma) | `npm run dev:api` or `npm run dev` | 4000                |
+| Web (Vite + React)     | `npm run dev:web` or `npm run dev` | 5173                |
 
 ### Quick start (after update script has run)
 
@@ -25,6 +25,7 @@
 ### Key development commands
 
 See `README.md` "Development Commands" section. Summary:
+
 - `npm run lint` — ESLint + Prettier + TypeScript type-check (all workspaces)
 - `npm run test` — Vitest across shared/api/web packages
 - `npm run build` — production build (shared → api → web)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for Cloud Agents.

### What's included

- **Service overview table** — PostgreSQL, API (Fastify+Prisma), and Web (Vite+React) with ports
- **Quick start steps** — Docker daemon, postgres, migrations, dev servers
- **Key development commands** — lint, test, build, dev references to README
- **Non-obvious caveats** discovered during environment setup:
  - First login auto-creates the Treemich account (no separate signup)
  - `npm run lint` and `npm run test` build `@treemich/shared` first
  - Prisma client generation required after `npm install`
  - Docker in Cloud VMs needs `fuse-overlayfs` + `iptables-legacy`
  - `TREEMICH_ENCRYPTION_KEY` (64-char hex) required or API crashes
  - Immich is entirely optional

### Evidence of working environment

[Treemich 3D tree view](https://cursor.com/agents/bc-9f3ea063-464a-4760-b98b-45b9fc04c354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftreemich_tree_view.webp)

Tree view showing people and relationships in 3D interactive graph.

[Treemich login page](https://cursor.com/agents/bc-9f3ea063-464a-4760-b98b-45b9fc04c354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftreemich_login_page.webp)

Login page accessible at localhost:5173.

API demo output showing successful account creation, people creation, and relationship management:

[hello_world_api_demo.log](https://cursor.com/agents/bc-9f3ea063-464a-4760-b98b-45b9fc04c354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_api_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f3ea063-464a-4760-b98b-45b9fc04c354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f3ea063-464a-4760-b98b-45b9fc04c354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

